### PR TITLE
Issue 4: Display the IT request category list

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,7 +7,6 @@ type UiState = "idle" | "loading" | "success" | "error";
 export default function App() {
   const [state, setState] = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
-  void categories;
 
   async function handleCheck() {
     setState("loading");
@@ -36,9 +35,20 @@ export default function App() {
       )}
 
       {state === "success" && (
-        <div className="alert alert-success mt-3 mb-0" role="status">
-          System Status: Online
-        </div>
+        <>
+          <div className="alert alert-success mt-3 mb-0" role="status">
+            System Status: Online
+          </div>
+
+          <h2 className="h5 mt-4">Request Categories</h2>
+          <ul className="list-group">
+            {categories.map((category) => (
+              <li key={category.id} className="list-group-item">
+                {category.name}
+              </li>
+            ))}
+          </ul>
+        </>
       )}
 
       {state === "error" && (
@@ -47,8 +57,6 @@ export default function App() {
           <div>Unable to connect to TokTickIT API</div>
         </div>
       )}
-
-      {/* TODO(Issue 4): render the category list inside the success state. */}
     </div>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -11,11 +11,11 @@ export interface SystemStatus {
 }
 
 // Issue 2 — call the backend health endpoint.
-// Throwing on failure lets the UI show a single Offline/error state.
+// Issue 4 — then fetch the seeded categories.
+// Throwing on either failure lets the UI show a single Offline/error state.
 // The timeout covers the case where the backend accepts the connection but
 // never responds — without it the UI would stay on "Checking system" forever.
-// TODO(Issue 4): after GET /api/categories exists, fetch it here and return
-// the real list instead of the empty array below.
+// Each fetch needs its own signal; a timeout signal cannot be reused.
 export async function checkSystem(): Promise<SystemStatus> {
   const res = await fetch(`${API_URL}/api/health`, {
     signal: AbortSignal.timeout(5000),
@@ -24,5 +24,13 @@ export async function checkSystem(): Promise<SystemStatus> {
     throw new Error(`Health check failed with status ${res.status}`);
   }
 
-  return { online: true, categories: [] };
+  const categoriesRes = await fetch(`${API_URL}/api/categories`, {
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!categoriesRes.ok) {
+    throw new Error(`Category fetch failed with status ${categoriesRes.status}`);
+  }
+
+  const categories = (await categoriesRes.json()) as Category[];
+  return { online: true, categories };
 }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -1,17 +1,59 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import App from "../../src/App.js";
+import * as api from "../../src/api.js";
 
 describe("App", () => {
+  // Without this, a mock set in one test leaks into the next.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   // WORKED EXAMPLE — provided for you.
   it("renders the TokTickIT heading", () => {
     render(<App />);
     expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
   });
 
-  // Issue 4 — write these yourself. Hint: mock the api module with
-  // vi.spyOn(api, "checkSystem").mockResolvedValue(...) / .mockRejectedValue(...)
-  // then click the button and assert the Online list / Offline message.
-  it.todo("shows Online and the seeded categories on success");
-  it.todo("shows an Offline error message when the API is unavailable");
+  it("shows Online and the seeded categories on success", async () => {
+    vi.spyOn(api, "checkSystem").mockResolvedValue({
+      online: true,
+      categories: [
+        { id: 1, name: "Account and Access" },
+        { id: 2, name: "Hardware" },
+        { id: 3, name: "Software" },
+        { id: 4, name: "Network" },
+      ],
+    });
+
+    render(<App />);
+    await userEvent.click(screen.getByRole("button", { name: /check system/i }));
+
+    expect(await screen.findByText("System Status: Online")).toBeInTheDocument();
+
+    // Assert order, not just presence — the list must mirror the API's order.
+    const items = screen.getAllByRole("listitem");
+    expect(items.map((li) => li.textContent)).toEqual([
+      "Account and Access",
+      "Hardware",
+      "Software",
+      "Network",
+    ]);
+  });
+
+  it("shows an Offline error message when the API is unavailable", async () => {
+    vi.spyOn(api, "checkSystem").mockRejectedValue(new Error("network failure"));
+
+    render(<App />);
+    await userEvent.click(screen.getByRole("button", { name: /check system/i }));
+
+    expect(await screen.findByText("System Status: Offline")).toBeInTheDocument();
+    expect(
+      screen.getByText("Unable to connect to TokTickIT API"),
+    ).toBeInTheDocument();
+
+    // No stale list left behind from a previous successful check.
+    expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+  });
 });

--- a/docs/lab-01/ai_use.md
+++ b/docs/lab-01/ai_use.md
@@ -1,13 +1,182 @@
-# Lab 1 — AI Use and Reflection  (fill this in)
+# Lab 1 — AI Use
 
-**LLM/agent used:** <name>
+**LLM / agent used:** Claude (Anthropic), via the claude.ai web interface.
+Filesystem read/write access to the project directory in later sessions. All
+shell and git commands were run by me; the agent could read and write files but
+could not execute anything.
 
-## Selected key prompts (6–10)
-| # | Prompt (summarised) | What I did with the result |
-|---|---------------------|----------------------------|
-| 1 |  |  |
-| 2 |  |  |
+---
+
+## Prompt 1
+
+**Actual Prompt Text:**
+> lets start check on issue 1 : set up project. List what have to be done and ask me question if want to know more
+
+**What the agent did:** Listed the seven Issue 1 acceptance criteria with what each required, and asked two clarifying questions about my machine state instead of assuming it.
+
+**My Reflection:**
+Knowing what ai can do and what I need to do and see the picture before doing it.
+
+---
+
+## Prompt 2
+
+**Actual Prompt Text:**
+> lets go step by step. For step 1 where to run that code
+
+**What the agent did:** Reduced its output from a block of commands to one command at a time, with the working directory stated.
+
+**My Reflection:**
+Going step by step can let me know what ai goin to do and where we are now.
+
+---
+
+## Prompt 3
+
+**Actual Prompt Text:**
+> lets start with ai_use.md where to store it where to start
+
+**What the agent did:** Stated it had no write access to my filesystem and told me to create the file by hand. It then checked again and found it did have write access.
+
+**My Reflection:**
+I want ai to track what we have done in md file. And ai may make some mistake because ai did not check, so I have to told them to check.
+
+---
+
+## Prompt 4
+
+**Actual Prompt Text:**
+> TokTickIT — CPE 334 Lab 1, Issue 2: Implement the API health check.
+> CONTEXT
+> - Windows 10, Command Prompt (not bash). `cd /d` needed to switch drives. No `&&` chaining.
+> - Repo: D:\SoftwareEng\TokTickIT — github.com/Chanat-888/TokTickIT
+> - I am on branch feature/2-health-check, stacked on feature/1-project-foundation
+>   (Issue 1's PR #5 is open into lab1-staging but not merged yet).
+> - Stack: client = Vite+React+TS+Bootstrap, server = Express+TS+Prisma+PostgreSQL.
+> - Issue 1 is done: both servers start, Postgres 17 running, DB `toktickit` created.
+> ACCEPTANCE CRITERIA (from the labsheet — these are what get graded)
+> - GET /api/health returns HTTP 200
+> - JSON response contains status = "ok" and service = "TokTickIT API"
+> - A Supertest test verifies the endpoint
+> - The React page displays the backend status based on a real API call
+> - A useful error message appears when the backend is unavailable
+> SCOPE DECISION ALREADY MADE — do not re-litigate
+> The scaffold comments mark App.tsx and api.ts as "Issue 4", but the labsheet
+> puts the backend-status UI in Issue 2. Follow the labsheet.
+> checkSystem() must be HEALTH-ONLY in this issue: fetch /api/health, throw if
+> not ok, return { online: true, categories: [] }. The categories fetch is added
+> in Issue 4. Do not fetch /api/categories now — it isn't implemented and would
+> make the UI show Offline permanently.
+> FILES TO CHANGE (all four, minimum surgical edits)
+> 1. server/src/app.ts — replace the 501 stub in the /api/health handler with the
+>    required 200 response. The existing test asserts exact object equality, so
+>    no extra fields.
+> 2. client/src/api.ts — implement checkSystem() per the scope decision above.
+> 3. client/src/App.tsx — wire handleCheck with try/catch; render idle / loading /
+>    success / error. Use Bootstrap classes. Match the labsheet wording exactly:
+>      Success: "System Status: Online"
+>      Failure: "System Status: Offline" and "Unable to connect to TokTickIT API"
+>    (Part 4 grades a screenshot against this wording.)
+> 4. client/.env — copy from client/.env.example (gitignored).
+> DO NOT
+> - Do not implement GET /api/categories or the Prisma Category model (Issue 3/4).
+> - Do not fill in the two `it.todo` tests in client/tests/lab-01/App.test.tsx —
+>   they are Issue 4's.
+> - Do not run `npm audit fix --force`.
+> - Do not run `npx prisma migrate dev` (schema has no models until Issue 3).
+> - Do not commit .env or node_modules.
+> VERIFY BEFORE I COMMIT
+> - cd server, npm test → the health Supertest test passes. Paste the output.
+> - Both servers running, click [Check System] in the browser → "System Status: Online".
+> - Stop the backend, click again → Offline + the error message. Screenshot this.
+> WORKING STYLE
+> Go one step at a time and wait for my terminal output before the next step.
+> Be direct, tell me if I'm wrong, give one recommendation not a list of options.
+> I paste raw output rather than summarising — read it yourself.
+> You have filesystem access to D:\ and can read/write project files, but cannot
+> run shell or git commands. I run those.
+> Start by reading server/src/app.ts, client/src/api.ts, client/src/App.tsx and
+> server/tests/lab-01/health.test.ts, then give me step 1.
+
+**What the agent did:** Changed four files, kept `checkSystem()` health-only, and did not touch the Issue 4 items listed under DO NOT.
+
+**My Reflection:**
+Using ai to help create prompt make the prompt more effective and accurate.
+
+---
+
+## Prompt 5
+
+**Actual Prompt Text:**
+> for reviewer.md where to look in pdf what ta want?
+
+**What the agent did:** Stated it did not have the labsheet PDF and could not cite a section. After I uploaded it, the agent located the Part 1 "PR Review Evidence, 5 points" spec and retracted an earlier claim that the Part 4 failure screenshot had to be committed to the repo.
+
+**My Reflection:**
+I give ai the pdf to see what is needed.
+
+---
+
+## Prompt 6
+
+**Actual Prompt Text:**
+> isnt there should be screenshots folder here? where it gone
+
+**What the agent did:** Had me run `git log --oneline -1 feature/2-health-check` to show commit 87491a5 still held the folder, which had disappeared from Explorer after a branch checkout.
+
+**My Reflection:**
+I'm new to git so I learn that file change with what branch I working on.
+
+---
+
+## Prompt 7
+
+**Actual Prompt Text:**
+> I want to start issue 3. Plan how to do it
+
+**What the agent did:** Read schema.prisma, seed.ts, package.json and .env before answering. Identified that package.json already wires a Prisma seed hook, so the seed had to be written before running `migrate dev`. In the same session it made two claims that were later disproved: that the README would cause a permission error on Postgres 15+ (retracted after it read the README), and that `migrate dev` would auto-run the seed (the terminal output showed it did not).
+
+**My Reflection:**
+When start to do something I let ai plan what to do first.
+
+---
+
+## Prompt 8
+
+**Actual Prompt Text:**
+> what to do with the one in main??
+
+**What the agent did:** Argued against using the Revert button on PR #7, on the grounds that a revert leaves the commits in main's ancestry so the release PR would skip re-applying them. Recommended opening PR #8 to re-target the same commits onto lab1-staging instead.
+
+**My Reflection:**
+Made some mistake and merge to main so try to find way out of this problem.
+
+---
+
+## Prompt 9
+
+**Actual Prompt Text:**
+> can you try edit again?
+
+**What the agent did:** After a filesystem tool timeout, re-read the file rather than re-applying the edit from memory, and found the working tree was on the wrong branch.
+
+**My Reflection:**
+If some tools is broken I need to ask ai the check it again.
+
+---
+
+## Prompt 10
+
+**Actual Prompt Text:**
+> I want to start issue 4. plan it for me
+
+**What the agent did:** Read the repo, then searched earlier sessions and reported that the reverse peer review I had recorded as outstanding had in fact been completed. Later in the same session it wrote this file in my first person without being asked, which I stopped and reverted to this skeleton.
+
+**My Reflection:**
+Same as previous issue, I let ai plan for me first before working on it, So I can know where/what to do first.
+
+---
 
 ## Reflection
-Two or three sentences: what made your prompts better, and one place you had to
-correct or reject what the agent produced.
+
+I think lets ai plan everytime before doing work is the best way to start and let ai ask more question to let ai see the same picture as you. And check what ai doing and the result everytime you do work. And for prompt part let ai help you prompt is good for dont do this dont do that, but it may not necessary everytime.

--- a/docs/lab-01/reviewer.md
+++ b/docs/lab-01/reviewer.md
@@ -1,19 +1,117 @@
-# Lab 1 — Peer Review Record  (fill this in)
+# Lab 1 — Peer Review Record
 
-**Author:** <your name> — <student id> — GitHub: @<username>
-**Peer reviewer:** <partner name> — <student id> — GitHub: @<username>
+**Author:** Chanat Dachkumhang — 67070503409 — GitHub: @Chanat-888
+**Peer reviewer:** Jeerasak Phisawong — 67070503461 — GitHub: @ShitheadQuin
+
+Repository under review (mine): https://github.com/Chanat-888/TokTickIT
+Repository I reviewed (partner's): https://github.com/ShitheadQuin/Toktickit
+
+---
 
 ## Pull Requests I authored (reviewed by my partner)
-| PR | Branch | Reviewer verdict |
-|----|--------|------------------|
-|    | feature/1-project-foundation |  |
-|    | feature/2-health-check |  |
-|    | feature/3-category-seed |  |
-|    | feature/4-category-list |  |
 
-Reviewer comment I received: <...>
-How I responded: <...>
+| PR | Branch | Base | Reviewer verdict |
+|----|--------|------|------------------|
+| [#5](https://github.com/Chanat-888/TokTickIT/pull/5) | feature/1-project-foundation | lab1-staging | Approved, after two inline comments and a fix commit |
+| [#6](https://github.com/Chanat-888/TokTickIT/pull/6) | feature/2-health-check | lab1-staging | Approved, after two inline comments and a fix commit |
+| [#7](https://github.com/Chanat-888/TokTickIT/pull/7) | feature/3-category-seed | main *(mis-targeted — see note)* | Approved |
+| [#8](https://github.com/Chanat-888/TokTickIT/pull/8) | feature/3-category-seed | lab1-staging | Approved |
+| [#9](https://github.com/Chanat-888/TokTickIT/pull/9) | feature/4-category-list | lab1-staging | *(pending)* |
+
+**Note on #7 and #8.** PR #7 was opened against `main` by mistake — GitHub
+defaults the base branch to the repository default and I did not change it. It
+was reviewed and merged before I noticed. I deliberately did not revert it: a
+revert commit does not remove commits from a branch's ancestry, it only undoes
+their effect, so the later release PR would have treated Issue 3 as already
+merged, skipped re-applying it, and left `main` without the `Category` model
+and with failing tests — with nothing in the diff to explain why. Instead I
+opened PR #8 re-targeting the same commits onto `lab1-staging`. Both branches
+now share those commits, so the release PR diffs cleanly to Issues 2 and 4.
+
+### Reviewer comment I received
+
+On PR #5, against `server/.env.example`, Jeerasak flagged a setup gap:
+
+> "This connects using the toktickit role, but the README only shows how to
+> create the toktickit database. Where is the toktickit role created? It seems
+> like the README might be missing a CREATE ROLE step for anyone setting this up
+> from scratch."
+
+### How I responded
+
+He was right — the README created the database but never created the
+`toktickit` role that `.env.example` connects as, so a clean setup would have
+failed on authentication. I fixed it in commit `18bd928`: added `CREATE ROLE`
+before `CREATE DATABASE`, plus a note for anyone reusing an existing role.
+Tracing it also surfaced a second gap he hadn't asked about — the README never
+mentioned copying `client/.env.example` to `client/.env` — so I added that step
+in the same commit.
+
+He left a second inline comment on `client/src/App.tsx` confirming Bootstrap was
+not merely installed but actually wired in and used (`container`, `btn
+btn-success`). That one needed no action.
+
+### A second cycle, on PR #6
+
+He left two inline comments. On `client/src/api.ts` he asked whether the UI
+would ever leave the loading state if the backend hung rather than refusing the
+connection outright. It would not: `fetch` has no default timeout, and my
+offline test had not caught it because a stopped server refuses immediately. I
+added `AbortSignal.timeout(5000)` in commit `d80743c`, which surfaces through
+the same `catch` as the Offline message, and replied on the thread explaining
+why the original test missed it.
+
+His second comment, on `client/src/App.tsx`, endorsed keeping the error message
+generic rather than rendering the raw fetch error. I replied that the specific
+error stays in the thrown `Error` while the UI shows the generic text, so
+nothing internal leaks. He approved after both replies and I merged `f25aa38`.
+
+---
 
 ## Pull Requests I reviewed for my partner
-My comment: <...>
-Partner's response: <...>
+
+Partner's repository: https://github.com/ShitheadQuin/Toktickit
+
+| PR | What I found | Verdict | His response |
+|----|--------------|---------|--------------|
+| [#5](https://github.com/ShitheadQuin/Toktickit/pull/5) | `Closes#1` written without a space, so GitHub linked no issue; `.env` rule missing from `client/.gitignore`; stock Vite README left in place | Approved, then re-approved after his fix commit | Fixed both files, merged `7b22fbd` |
+| [#6](https://github.com/ShitheadQuin/Toktickit/pull/6) | No timeout on `fetch('/api/health')` — a hung backend leaves the UI on "Loading…" instead of reaching the error state | Approved | Added `AbortSignal.timeout(5000)` in `60a6952` |
+| [#7](https://github.com/ShitheadQuin/Toktickit/pull/7) | Queried a missing seed command in `package.json`, then withdrew it — the seed resolves through `prisma.config.ts`'s `migrations.seed` under the Prisma 7 convention, so the documented `npx prisma db seed` works | Approved | Merged `933514b` |
+
+The PR #6 finding is the same defect Jeerasak raised on my own PR #6, found
+independently in both directions on the same day.
+
+The full comment → fix → re-review cycle is documented below, using PR #5.
+
+### My comment
+
+I reviewed the full diff and confirmed the scaffold was sound: Bootstrap
+imported in `main.tsx`, Vitest wired through `"test": "vitest run"`, both
+`client/tests/lab-01/` and `server/tests/lab-01/` present, and `.env.example`
+committed with no real `.env` leaked.
+
+The substantive finding was outside the code. The PR body read `Closes#1`
+without a space, so GitHub was not parsing it as a closing keyword — the
+Development sidebar showed no linked issue, which meant merging the PR would
+not have closed Issue #1 or moved the board card. I asked him to change it to
+`Closes #1`. I also left two minor inline comments, on `client/.gitignore`
+(missing a `.env` rule) and `client/README.md` (still the stock Vite starter
+text).
+
+### Partner's response
+
+He pushed a fix commit adding the `.env` rule to `client/.gitignore` and
+removing the stock Vite README. I re-reviewed after that commit, confirmed both
+were resolved, and approved a second time. He then added the PR to his
+*TokTickIT Individual Sprints* board, moved it to PR Review, and merged commit
+`7b22fbd` into `lab1-staging`.
+
+This was a full comment → fix → re-review cycle rather than a single pass.
+
+### Withdrawing my own finding on PR #7
+
+On PR #7 I first flagged that `server/package.json` had no seed command, which
+would have made the README's seed step unrunnable. Checking `prisma.config.ts`
+before he replied showed I was wrong: under the Prisma 7 convention the seed
+resolves through `migrations.seed` there rather than through `package.json`. I
+withdrew the comment in my review, stated why, and approved.

--- a/docs/lab-01/tests.md
+++ b/docs/lab-01/tests.md
@@ -1,13 +1,110 @@
-# Lab 1 — Test Plan and Evidence  (fill this in)
+# Lab 1 — Test Plan and Evidence
 
-All test files live under server/tests/lab-01/ and client/tests/lab-01/.
+All test files live under `server/tests/lab-01/` and `client/tests/lab-01/`.
 
-| # | Tool | Test | Result |
-|---|------|------|--------|
-| 1 | Supertest | GET /api/health returns 200, status=ok | |
-| 2 | Supertest | GET /api/categories returns 4 seeded categories in id order | |
-| 3 | Vitest | Heading renders | |
-| 4 | Vitest | Success state shows Online + category list | |
-| 5 | Vitest | Error state shows Offline + message | |
+## Test cases
 
-Paste your passing terminal output / screenshot below.
+| Test File | Path | Tool | Test Description |
+|-----------|------|------|------------------|
+| API-01 | `server/tests/lab-01/health.test.ts` | Supertest | Health endpoint returns 200 and expected JSON |
+| API-02 | `server/tests/lab-01/categories.test.ts` | Supertest | Categories endpoint returns the four seeded categories |
+| UI-01 | `client/tests/lab-01/App.test.tsx` | Vitest | TokTickIT heading renders |
+| UI-02 | `client/tests/lab-01/App.test.tsx` | Vitest | Loading state changes to Online plus the category list |
+| UI-03 | `client/tests/lab-01/App.test.tsx` | Vitest | API failure displays a useful error message |
+
+## What each test asserts
+
+**API-01 — `server/tests/lab-01/health.test.ts`**
+Requests `/api/health` through Supertest and asserts HTTP 200 with a response
+body exactly equal to `{ status: "ok", service: "TokTickIT API" }`. Supertest
+imports the Express `app` directly, so no port is opened.
+
+**API-02 — `server/tests/lab-01/categories.test.ts`**
+Requests `/api/categories` and asserts HTTP 200, a four-item body, and the
+category names in the order `Account and Access, Hardware, Software, Network`.
+Ordering is checked a second time against the `id` values directly, so the
+`orderBy` clause is verified independently of the seed order. A final assertion
+confirms each object exposes only `id` and `name` — `createdAt` must not leak
+into the API response.
+
+The assertion deliberately matches on **names rather than literal ids**.
+Dropping and re-seeding the table does not restart the PostgreSQL autoincrement
+sequence, so hard-coding `id: 1..4` would fail against correct code after a
+re-seed.
+
+**UI-01 — `client/tests/lab-01/App.test.tsx`**
+Renders `App` and asserts the TokTickIT heading is present. Worked example
+supplied with the scaffold.
+
+**UI-02 — `client/tests/lab-01/App.test.tsx`**
+Mocks `checkSystem` with `vi.spyOn(...).mockResolvedValue(...)` returning the
+four categories, clicks **Check System**, then asserts the `System Status:
+Online` alert appears and the rendered list items match the four names *in
+order*. Comparing the full list rather than checking each name individually
+means a scrambled list fails.
+
+**UI-03 — `client/tests/lab-01/App.test.tsx`**
+Mocks `checkSystem` with `.mockRejectedValue(...)`, clicks the button, and
+asserts both `System Status: Offline` and `Unable to connect to TokTickIT API`
+render, and that no list items remain on screen. `vi.restoreAllMocks()` in
+`afterEach` prevents the success mock from leaking into this test.
+
+## Prerequisites
+
+The client suite mocks the API module, so it needs neither a running backend nor
+a database.
+
+The server suite is different: API-02 queries PostgreSQL through Prisma. The
+database service must be running and the seed applied (`npm run prisma:seed`)
+before `npm test` in `server/`. The backend dev server does **not** need to be
+running — Supertest imports the app without binding a port, which is why
+`src/app.ts` and `src/index.ts` are kept separate.
+
+## Passing runs
+
+Server — `cd /d D:\SoftwareEng\TokTickIT\server` then `npm test`:
+
+```
+D:\SoftwareEng\TokTickIT\server>npm test
+
+> toktickit-server@1.0.0 test
+> vitest run
+
+
+ RUN  v2.1.9 D:/SoftwareEng/TokTickIT/server
+
+ ✓ tests/lab-01/categories.test.ts (1) 745ms
+ ✓ tests/lab-01/health.test.ts (1)
+
+ Test Files  2 passed (2)
+      Tests  2 passed (2)
+   Start at  14:22:53
+   Duration  6.40s (transform 248ms, setup 0ms, collect 8.93s, tests 760ms, environment 0ms, prepare 1.52s)
+```
+
+Client — `cd /d D:\SoftwareEng\TokTickIT\client` then `npm test`:
+
+```
+D:\SoftwareEng\TokTickIT\client>npm test
+
+> toktickit-client@1.0.0 test
+> vitest run
+
+ RUN  v2.1.9 D:/SoftwareEng/TokTickIT/client
+
+ ✓ tests/lab-01/App.test.tsx (3)
+   ✓ App (3)
+     ✓ renders the TokTickIT heading
+     ✓ shows Online and the seeded categories on success
+     ✓ shows an Offline error message when the API is unavailable
+
+ Test Files  1 passed (1)
+      Tests  3 passed (3)
+   Start at  14:22:59
+   Duration  24.39s (transform 298ms, setup 3.48s, collect 4.56s, tests 182ms, environment 14.78s, prepare 789ms)
+```
+
+Note the skipped count is zero in both suites. The scaffold shipped
+`categories.test.ts` wrapped in `describe.todo` and `App.test.tsx` with two
+`it.todo` placeholders; those report green while executing nothing, so the
+suites were only meaningful once the `.todo` markers were removed.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,8 +2,7 @@ import express, { Request, Response } from "express";
 import cors from "cors";
 import { getPrisma } from "./prisma.js";
 // getPrisma() is your lazy database handle. Call it INSIDE a route when you
-// need the DB (Issue 4). It is intentionally unused until then.
-void getPrisma;
+// need the DB.
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -23,11 +22,22 @@ app.get("/api/health", (_req: Request, res: Response) => {
 
 // ---------------------------------------------------------------------------
 // Issue 4 — Category list
-// Add:  GET /api/categories
-//   -> read categories from PostgreSQL via getPrisma().category.findMany(...)
-//   -> return each { id, name } in a predictable (id) order
-//   -> on failure, respond 500 with a safe message (no internal details)
-// TODO(Issue 4): implement the route here.
+// Returns every seeded category as { id, name }, ordered by id so the list is
+// deterministic for both the UI and the Supertest assertion.
 // ---------------------------------------------------------------------------
+app.get("/api/categories", async (_req: Request, res: Response) => {
+  try {
+    const categories = await getPrisma().category.findMany({
+      orderBy: { id: "asc" },
+      select: { id: true, name: true },
+    });
+    res.status(200).json(categories);
+  } catch (err) {
+    // Log the real error server-side; send the client a message that leaks
+    // nothing about the database or the query.
+    console.error("GET /api/categories failed:", err);
+    res.status(500).json({ error: "Unable to load categories" });
+  }
+});
 
 export default app;

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -1,15 +1,29 @@
 import { describe, it, expect } from "vitest";
 import request from "supertest";
 import { app } from "../../src/app.js";
-void request; void app;
 
-// Issue 4 — write this test yourself, using health.test.ts as the pattern.
-// Requires the DB to be migrated and seeded first.
-// It should assert: GET /api/categories returns 200 and the four seeded
-// category names in id order.
-describe.todo("GET /api/categories", () => {
-  it.todo("returns the four seeded categories in id order", async () => {
-    // TODO(Issue 4): implement this assertion.
-    expect(true).toBe(true);
+// Issue 4 — requires the database to be migrated and seeded before running.
+describe("GET /api/categories", () => {
+  it("returns the four seeded categories in id order", async () => {
+    const res = await request(app).get("/api/categories");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(4);
+
+    // Assert on names, not literal ids: wiping and re-seeding preserves this
+    // order but does not restart the autoincrement sequence at 1.
+    expect(res.body.map((c: { name: string }) => c.name)).toEqual([
+      "Account and Access",
+      "Hardware",
+      "Software",
+      "Network",
+    ]);
+
+    // Ordering criterion, checked independently of the names.
+    const ids = res.body.map((c: { id: number }) => c.id);
+    expect(ids).toEqual([...ids].sort((a: number, b: number) => a - b));
+
+    // The route exposes only id and name — createdAt must not be returned.
+    expect(Object.keys(res.body[0]).sort()).toEqual(["id", "name"]);
   });
 });


### PR DESCRIPTION
Closes #4

Adds the categories endpoint and the category list UI, completing the Lab 1 vertical slice.

- `GET /api/categories` returns `{ id, name }` per category, ordered by `id` ascending, sourced from PostgreSQL through Prisma
- Supertest test in `server/tests/lab-01/categories.test.ts` asserts the four seeded categories, ascending ids, and that `createdAt` does not leak into the response
- `checkSystem()` now fetches health then categories, each with its own 5s timeout
- `App.tsx` renders the categories from the API in a Bootstrap list group, not hard-coded values
- Two Vitest tests in `client/tests/lab-01/App.test.tsx` cover the success and error states

Also adds the three Lab 1 documents: `docs/lab-01/tests.md`, `docs/lab-01/ai_use.md`, and `docs/lab-01/reviewer.md`.

Server 2/2 and client 3/3 passing, output recorded in `tests.md`.