### PR TITLE
docs: add Lab 2 API spec, UI spec, test plan, and review record

### DIFF
--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -312,6 +312,7 @@ creation (BR-02).
 | 200 | Ticket representation (§0.3), identical to the original creation, no new row | replay of a previously used `Idempotency-Key` for this Requester (BR-11) |
 | 400 | `{ errors: [{ field, message }] }`, one entry per failing field | see table below |
 | 400 | `{ "errors": [{ "field": "X-Requester-Id", "message": "Missing or invalid requester header" }] }` | `X-Requester-Id` missing/non-integer (§0.1) |
+| 400 | `{ "errors": [{ "field": "Idempotency-Key", "message": "Missing or invalid idempotency key" }] }` | `Idempotency-Key` missing, or present but not a valid UUID (BR-11) |
 | 403 | `{ "error": "Selected Requester is not active" }` | `X-Requester-Id` valid integer but not an active Requester (§0.1) |
 | 500 | `{ "error": "Unexpected server error" }` | unexpected failure (§0.2) |
 
@@ -324,7 +325,11 @@ Field-validation 400 triggers:
 | `summary` | missing, or trimmed length outside 5–120 | BR-14, BR-15 |
 | `description` | missing, or trimmed length outside 10–2000 | BR-14, BR-16 |
 | `requestedPriority` | missing or not one of `LOW`/`MEDIUM`/`HIGH` | BR-18 |
-| `Idempotency-Key` | missing, or not a valid UUID | BR-11 |
+
+The two header 400s in the Responses table above (`X-Requester-Id`,
+`Idempotency-Key`) are not request-body fields, so they are listed there
+with their exact message rather than in this body-field table. Both are
+checked before any body field is validated.
 
 On any 400, no Ticket is created (BR-19); the client is responsible for
 preserving already-entered field values (a `ui-spec.md`/client concern, not

--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -1,0 +1,963 @@
+# Lab 2 API Specification
+
+Source of truth: `specification.md` (merged, authoritative). This document
+expands specification.md §8 into per-endpoint detail. It does not add,
+narrow, or contradict any FR/BR/AC — every rule below cites the
+specification.md item it enforces. Nine details specification.md did not
+originally fix were resolved and are recorded, with their answer and
+reason, in §12 Resolved Decisions. Two of those resolutions also amend
+specification.md itself: OQ-2 renames the `GET /api/tickets` category
+filter to `categoryId` in specification.md §8, and OQ-7 makes BR-23's
+id-descending tiebreaker universal rather than default-only.
+
+No code, UI, or test content is included; see `ui-spec.md` and `tests.md`
+for those.
+
+---
+
+## 0. Conventions
+
+### 0.1 Which endpoints require `X-Requester-Id`
+
+specification.md §8 states: "All Ticket/Attachment endpoints require an
+`X-Requester-Id` header identifying the acting Development Requester." Read
+literally, this scopes the requirement to endpoints that operate on a
+Ticket or Attachment resource. The three reference-data endpoints (§1–§3
+below) are not Ticket/Attachment endpoints and are read below as **not**
+requiring the header — consistent with `GET /api/requesters` being the
+endpoint that populates the selector *before* any Requester is chosen
+(FR-01), which could not work if it itself demanded a chosen Requester's id.
+
+Endpoints requiring `X-Requester-Id`: `POST /api/tickets`,
+`GET /api/tickets`, `GET /api/tickets/:id`,
+`POST /api/tickets/:id/attachments`,
+`GET /api/tickets/:ticketId/attachments/:attachmentId`,
+`GET /api/tickets/:ticketId/attachments/:attachmentId/download`,
+`DELETE /api/tickets/:ticketId/attachments/:attachmentId`.
+
+For every one of those endpoints, the header is validated the same way
+before any endpoint-specific logic runs:
+
+| Header value | Response |
+|---|---|
+| Missing | `400` — `{ "errors": [{ "field": "X-Requester-Id", "message": "Missing or invalid requester header" }] }` |
+| Present but not an integer | `400` — `{ "errors": [{ "field": "X-Requester-Id", "message": "Missing or invalid requester header" }] }` |
+| Valid integer, no active RequesterUser with that id | `403` — `{ error: "Selected Requester is not active" }` |
+| Valid integer, matches an active RequesterUser | proceeds to endpoint logic, scoped to that Requester (FR-14, BR-09) |
+
+This enforces BR-09 (ownership checked on every read/write), BR-37 (the
+header is Lab 2's temporary auth substitute), and is what makes BR-10/BR-36
+(cross-Requester access → 404) and BR-04 (Requester fixed server-side, not
+client-supplied in the body) possible.
+
+Per-endpoint sections below reference this table rather than repeating it,
+except where an endpoint has additional header-driven behavior (e.g.
+`Idempotency-Key` on `POST /api/tickets`).
+
+### 0.2 Fixed error body shapes
+
+specification.md §8 fixes these shapes for every endpoint in this API — no
+endpoint below overrides them:
+
+- **400** (field validation failure): `{ errors: [{ field, message }] }` —
+  one entry per invalid field.
+- **403 / 404 / 409 / 413 / 415 / 500**: `{ error: string }` — a single
+  generic message with no per-field detail, since none of these originate
+  from one specific form field.
+
+Fixed wordings (specification.md §8, "Error response bodies"):
+
+| Status | Body |
+|---|---|
+| 403 | `{ "error": "Selected Requester is not active" }` |
+| 404 | `{ "error": "Not found" }` — identical wording whether the resource is missing or owned by a different Requester (BR-10, BR-36) |
+| 409 (too many files) | `{ "error": "Too many files in this request" }` |
+| 409 (attachment cap) | `{ "error": "Attachment limit reached" }` |
+| 409 (double removal) | `{ "error": "Attachment already removed" }` |
+| 413 | `{ "error": "File exceeds 5 MB" }` |
+| 415 | `{ "error": "Unsupported file type" }` |
+| 500 | `{ "error": "Unexpected server error" }` — the real error is logged server-side only |
+
+### 0.3 Resource representations
+
+These field sets are assembled from specification.md §7 (Data Changes) and
+the explicit response shapes fixed in §8. They are reused across the
+endpoints below rather than redefined per endpoint.
+
+**Ticket representation** — one shared shape across create, list, and
+detail (Resolved Decision OQ-3, §12): `POST /api/tickets` returns exactly
+this; `GET /api/tickets` list items use it unchanged; `GET /api/tickets/:id`
+uses it with `attachments: Attachment[]` added, nothing else:
+
+```
+{
+  id: integer,
+  ticketNumber: string,        // "TKT-YYYY-NNNNNN", BR-01
+  requesterId: integer,
+  categoryId: integer,
+  relatedSystemId: integer,
+  summary: string,
+  description: string,
+  requestedPriority: "LOW" | "MEDIUM" | "HIGH",
+  status: "NEW",
+  createdAt: string,            // ISO 8601
+  updatedAt: string             // ISO 8601
+}
+```
+
+`idempotencyKey` is a stored column (§7) but is not part of the fixed
+response shape in §8 and is not exposed to the client.
+
+**Attachment representation** (used by
+`POST /api/tickets/:id/attachments`,
+`GET /api/tickets/:ticketId/attachments/:attachmentId`, the `attachments[]`
+array on `GET /api/tickets/:id`, and the `DELETE` response — all of which
+specification.md §8 describes as "Attachment metadata" carrying the
+removed-state fields):
+
+```
+{
+  id: integer,
+  ticketId: integer,
+  originalFilename: string,
+  mimeType: string,
+  sizeBytes: integer,
+  createdAt: string,             // ISO 8601
+  isRemoved: boolean,
+  removedAt: string | null,      // ISO 8601 or null
+  removalReason: string | null
+}
+```
+
+`storedFilename` is a stored column (§7) used server-side to locate the
+file; per Resolved Decision OQ-4 (§12), it is never returned in any
+client-facing response and is omitted above.
+
+---
+
+## 1. `GET /api/categories`
+
+**Purpose**: active Categories, for the Create Ticket category dropdown
+(existing Lab 1 endpoint; FR-02 depends on it, BR-17 enforces the
+"currently active" constraint at ticket-creation time).
+
+**Headers**: none required (§0.1).
+
+**Params**: none.
+
+**Responses**:
+
+| Status | Body |
+|---|---|
+| 200 | `Array<{ id: integer, name: string }>`, ordered by `id` ascending, active rows only |
+| 500 | `{ "error": string }` (§0.2) |
+
+**Worked example — success**
+
+```
+GET /api/categories
+```
+```json
+200 OK
+[
+  { "id": 1, "name": "Account and Access" },
+  { "id": 2, "name": "Hardware" },
+  { "id": 3, "name": "Software" },
+  { "id": 4, "name": "Network" }
+]
+```
+
+**Worked example — failure**
+
+```
+GET /api/categories
+```
+```json
+500 Internal Server Error
+{ "error": "Unexpected server error" }
+```
+(Per Resolved Decision OQ-5, §12, this endpoint adopts the generic 500
+wording rather than its prior implementation-specific text.)
+
+---
+
+## 2. `GET /api/related-systems`
+
+**Purpose**: active Related Systems, for the Create Ticket related-system
+dropdown. RelatedSystem "mirrors the existing Category shape" (§7), so its
+list endpoint mirrors `GET /api/categories`. Enforces the same "must
+reference a currently active row" constraint via BR-17 at ticket creation.
+
+**Headers**: none required (§0.1).
+
+**Params**: none.
+
+**Responses**:
+
+| Status | Body |
+|---|---|
+| 200 | `Array<{ id: integer, name: string }>`, ordered by `id` ascending, active rows only |
+| 500 | `{ "error": string }` (§0.2) |
+
+**Worked example — success**
+
+```
+GET /api/related-systems
+```
+```json
+200 OK
+[
+  { "id": 1, "name": "Email" },
+  { "id": 2, "name": "VPN" },
+  { "id": 3, "name": "Payroll Portal" },
+  { "id": 4, "name": "Shared Drive" },
+  { "id": 5, "name": "Ticketing System" },
+  { "id": 6, "name": "Printer Fleet" }
+]
+```
+
+**Worked example — failure**
+
+```
+GET /api/related-systems
+```
+```json
+500 Internal Server Error
+{ "error": "Unexpected server error" }
+```
+
+---
+
+## 3. `GET /api/requesters`
+
+**Purpose**: active Development Requesters, for the Requester Selection
+screen dropdown (FR-01, BR-05). BR-06 means an inactive Requester's
+tickets still exist but that Requester never appears here.
+
+**Headers**: none required (§0.1) — this is the endpoint that runs
+*before* a Requester is chosen.
+
+**Params**: none.
+
+**Responses**:
+
+| Status | Body |
+|---|---|
+| 200 | `Array<{ id: integer, name: string }>`, active rows only (BR-05) — resolved per OQ-6, §12 |
+| 500 | `{ "error": string }` (§0.2) |
+
+**Worked example — success**
+
+```
+GET /api/requesters
+```
+```json
+200 OK
+[
+  { "id": 1, "name": "Alex Rivera" },
+  { "id": 2, "name": "Sam Okafor" },
+  { "id": 3, "name": "Priya Nair" }
+]
+```
+(`{ id, name }` only, matching the Category/RelatedSystem convention —
+Resolved Decision OQ-6, §12. `email` is not returned.)
+
+**Worked example — failure**
+
+```
+GET /api/requesters
+```
+```json
+500 Internal Server Error
+{ "error": "Unexpected server error" }
+```
+
+---
+
+## 4. `POST /api/tickets`
+
+**Purpose**: create a Ticket (FR-02), returning a server-generated Ticket
+Number (FR-03, BR-01).
+
+**Headers**:
+
+| Header | Required | Rule |
+|---|---|---|
+| `X-Requester-Id` | yes | §0.1 table; fixes the Ticket's owner (BR-04) — the client cannot set `requesterId` via the body |
+| `Idempotency-Key` | yes | UUID; BR-11. A repeated key from the same Requester returns the original Ticket instead of creating a duplicate (BR-11, BR-12, AC-05) |
+
+**Path/query params**: none.
+
+**Request body**:
+
+```
+{
+  categoryId: integer,          // required; must reference an active Category (BR-17)
+  relatedSystemId: integer,     // required; must reference an active RelatedSystem (BR-17)
+  summary: string,              // required; trimmed server-side (BR-14), 5–120 chars after trim (BR-15)
+  description: string,          // required; trimmed server-side (BR-14), 10–2000 chars after trim (BR-16)
+  requestedPriority: "LOW" | "MEDIUM" | "HIGH"   // required (BR-18)
+}
+```
+
+`requesterId` and `status` are never accepted in the body — `requesterId`
+comes from `X-Requester-Id` (BR-04) and `status` is always `NEW` at
+creation (BR-02).
+
+**Responses**:
+
+| Status | Body | Trigger / BR |
+|---|---|---|
+| 201 | Ticket representation (§0.3) | created successfully |
+| 200 | Ticket representation (§0.3), identical to the original creation, no new row | replay of a previously used `Idempotency-Key` for this Requester (BR-11) |
+| 400 | `{ errors: [{ field, message }] }`, one entry per failing field | see table below |
+| 400 | `{ "errors": [{ "field": "X-Requester-Id", "message": "Missing or invalid requester header" }] }` | `X-Requester-Id` missing/non-integer (§0.1) |
+| 403 | `{ "error": "Selected Requester is not active" }` | `X-Requester-Id` valid integer but not an active Requester (§0.1) |
+| 500 | `{ "error": "Unexpected server error" }` | unexpected failure (§0.2) |
+
+Field-validation 400 triggers:
+
+| `field` | Condition | BR |
+|---|---|---|
+| `categoryId` | missing, not an integer, or does not reference a currently active Category | BR-17 |
+| `relatedSystemId` | missing, not an integer, or does not reference a currently active RelatedSystem | BR-17 |
+| `summary` | missing, or trimmed length outside 5–120 | BR-14, BR-15 |
+| `description` | missing, or trimmed length outside 10–2000 | BR-14, BR-16 |
+| `requestedPriority` | missing or not one of `LOW`/`MEDIUM`/`HIGH` | BR-18 |
+| `Idempotency-Key` | missing, or not a valid UUID | BR-11 |
+
+On any 400, no Ticket is created (BR-19); the client is responsible for
+preserving already-entered field values (a `ui-spec.md`/client concern, not
+part of the response body).
+
+BR-38's Ticket Number generation retries up to 5 times on a `ticketNumber`
+unique-constraint collision. If all 5 attempts collide, the request fails
+with the generic 500 (`{ "error": "Unexpected server error" }`, §0.2) — there
+is no distinct status or body for retry exhaustion.
+
+**Worked example — success (first submission)**
+
+```
+POST /api/tickets
+X-Requester-Id: 2
+Idempotency-Key: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+Content-Type: application/json
+
+{
+  "categoryId": 2,
+  "relatedSystemId": 4,
+  "summary": "Laptop won't power on after firmware update",
+  "description": "Laptop screen stays black after the scheduled firmware update finished overnight. Power light is on but nothing else responds.",
+  "requestedPriority": "HIGH"
+}
+```
+```json
+201 Created
+{
+  "id": 42,
+  "ticketNumber": "TKT-2026-000042",
+  "requesterId": 2,
+  "categoryId": 2,
+  "relatedSystemId": 4,
+  "summary": "Laptop won't power on after firmware update",
+  "description": "Laptop screen stays black after the scheduled firmware update finished overnight. Power light is on but nothing else responds.",
+  "requestedPriority": "HIGH",
+  "status": "NEW",
+  "createdAt": "2026-08-29T10:15:00.000Z",
+  "updatedAt": "2026-08-29T10:15:00.000Z"
+}
+```
+
+**Worked example — replay of the same `Idempotency-Key` (AC-05)**
+
+```
+POST /api/tickets
+X-Requester-Id: 2
+Idempotency-Key: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+Content-Type: application/json
+
+{
+  "categoryId": 2,
+  "relatedSystemId": 4,
+  "summary": "Laptop won't power on after firmware update",
+  "description": "Laptop screen stays black after the scheduled firmware update finished overnight. Power light is on but nothing else responds.",
+  "requestedPriority": "HIGH"
+}
+```
+```json
+200 OK
+{
+  "id": 42,
+  "ticketNumber": "TKT-2026-000042",
+  "requesterId": 2,
+  "categoryId": 2,
+  "relatedSystemId": 4,
+  "summary": "Laptop won't power on after firmware update",
+  "description": "Laptop screen stays black after the scheduled firmware update finished overnight. Power light is on but nothing else responds.",
+  "requestedPriority": "HIGH",
+  "status": "NEW",
+  "createdAt": "2026-08-29T10:15:00.000Z",
+  "updatedAt": "2026-08-29T10:15:00.000Z"
+}
+```
+No second row is created; the same `id`/`ticketNumber` is returned.
+
+**Worked example — failure (AC-04, AC-07)**
+
+```
+POST /api/tickets
+X-Requester-Id: 2
+Idempotency-Key: 6b1f0c2a-9d3e-4a11-8c2f-1e9b7d4a5f10
+Content-Type: application/json
+
+{
+  "categoryId": 9,
+  "relatedSystemId": 4,
+  "summary": "",
+  "description": "Printer jam",
+  "requestedPriority": "URGENT"
+}
+```
+```json
+400 Bad Request
+{
+  "errors": [
+    { "field": "categoryId", "message": "Category is not active" },
+    { "field": "summary", "message": "Summary is required" },
+    { "field": "description", "message": "Description must be at least 10 characters" },
+    { "field": "requestedPriority", "message": "Requested Priority must be LOW, MEDIUM, or HIGH" }
+  ]
+}
+```
+(specification.md fixes the field identified and the rule violated for
+each of these body-validation entries, but not the literal `message`
+text; wording shown is illustrative.)
+
+---
+
+## 5. `GET /api/tickets`
+
+**Purpose**: paginated, searchable, filterable, sortable list of the
+caller's own Tickets (FR-04, FR-05, FR-06, FR-07).
+
+**Headers**: `X-Requester-Id` (§0.1) — every result is scoped to this
+Requester only (BR-09); FR-04 guarantees the caller only ever sees their
+own tickets, never a query parameter for another Requester's id.
+
+**Query parameters**:
+
+| Param | Type | Allowed values | Default | Rule |
+|---|---|---|---|---|
+| `search` | string | any | none (no filter) | matches Ticket Number by **prefix**, or Summary by **case-insensitive substring** (BR-21, FR-05) |
+| `categoryId` | integer | any active Category `id` | none (no filter) | filters by Category (BR-22, FR-06) |
+| `requestedPriority` | string | `LOW`, `MEDIUM`, `HIGH` | none (no filter) | filters by Requested Priority (BR-22, FR-06) |
+| `status` | string | `NEW` (only value the enum can hold this sprint) | none (no filter) | filters by Current Status (BR-22, FR-06) |
+| `sortBy` | string | `createdAt`, `summary`, `requestedPriority`, `status` | `createdAt` | FR-07, BR-23 |
+| `sortDir` | string | `asc`, `desc` | `desc` | BR-23 |
+| `page` | integer | ≥ 1 | `1` | 1-based (BR-24) |
+| `pageSize` | integer | `10`, `20`, `50` | `10` | BR-24 |
+
+`categoryId` is rejected with 400 if it is not an integer, or is an
+integer that does not reference any existing Category row (active or
+not) — an unknown `categoryId` here is a query-string malformation, not
+the same thing as the `categoryId`/`relatedSystemId` **active-row**
+reference check on `POST /api/tickets` (BR-17), which is a body
+field-validation rule and rejects an inactive (not merely nonexistent)
+row.
+
+Default sort: `createdAt` descending, with Ticket `id` descending as a
+tiebreaker (BR-23). The `id`-descending tiebreaker applies to every sort,
+not only the default — see Resolved Decision OQ-7 in §12, which also
+amends specification.md BR-23.
+
+**Responses**:
+
+| Status | Body | Trigger / BR |
+|---|---|---|
+| 200 | `{ data: Ticket[], page: integer, pageSize: integer, totalCount: integer, totalPages: integer }` | success; `data` items use the shared Ticket representation (§0.3) |
+| 400 | `{ errors: [{ field, message }] }` | invalid `categoryId`, `sortBy`, `sortDir`, `requestedPriority`, or `status` value |
+| 403 | `{ "error": "Selected Requester is not active" }` | §0.1 |
+| 500 | `{ "error": "Unexpected server error" }` | §0.2 |
+
+Out-of-range `page`/`pageSize` values are **clamped, not rejected** — they
+never produce a 400. A `page` beyond the last available page returns an
+empty `data` array, not an error (BR-24, AC-09 implicitly, since it
+requires correct page-count metadata rather than an error path). Per
+Resolved Decision OQ-8 (§12): `page` below 1 clamps to 1; `pageSize`
+clamps to the nearest allowed value in `{10, 20, 50}`; the response's
+`page`/`pageSize` fields echo the clamped values actually used, not the
+values originally requested.
+
+**Pagination metadata shape** (fixed by specification.md §8):
+
+```
+{
+  data: Ticket[],
+  page: integer,
+  pageSize: integer,
+  totalCount: integer,
+  totalPages: integer
+}
+```
+
+**Worked example — success (AC-09)**
+
+```
+GET /api/tickets?sortBy=createdAt&sortDir=desc&page=1&pageSize=10
+X-Requester-Id: 1
+```
+```json
+200 OK
+{
+  "data": [
+    {
+      "id": 67,
+      "ticketNumber": "TKT-2026-000067",
+      "requesterId": 1,
+      "categoryId": 3,
+      "relatedSystemId": 5,
+      "summary": "Ticketing system login loop",
+      "description": "Signing in redirects back to the login page repeatedly.",
+      "requestedPriority": "MEDIUM",
+      "status": "NEW",
+      "createdAt": "2026-08-29T09:40:00.000Z",
+      "updatedAt": "2026-08-29T09:40:00.000Z"
+    }
+    // ... 9 more Tickets
+  ],
+  "page": 1,
+  "pageSize": 10,
+  "totalCount": 25,
+  "totalPages": 3
+}
+```
+
+**Worked example — failure (invalid filter/sort value)**
+
+```
+GET /api/tickets?status=RESOLVED
+X-Requester-Id: 1
+```
+```json
+400 Bad Request
+{
+  "errors": [
+    { "field": "status", "message": "Status must be NEW" }
+  ]
+}
+```
+(`RESOLVED` is not a value `TicketStatus` can hold in Lab 2 — see §7
+Enums.)
+
+---
+
+## 6. `GET /api/tickets/:id`
+
+**Purpose**: one owned Ticket with its Attachments (FR-08).
+
+**Headers**: `X-Requester-Id` (§0.1).
+
+**Path params**: `id` — integer, the Ticket's `id`.
+
+**Responses**:
+
+| Status | Body | Trigger / BR |
+|---|---|---|
+| 200 | Ticket representation (§0.3) plus `attachments: Attachment[]` (§0.3 representation) | found and owned by caller |
+| 403 | `{ "error": "Selected Requester is not active" }` | §0.1 |
+| 404 | `{ "error": "Not found" }` | Ticket does not exist, or is owned by a different Requester (BR-10, BR-36, AC-03) |
+| 500 | `{ "error": "Unexpected server error" }` | §0.2 |
+
+**Worked example — success**
+
+```
+GET /api/tickets/42
+X-Requester-Id: 2
+```
+```json
+200 OK
+{
+  "id": 42,
+  "ticketNumber": "TKT-2026-000042",
+  "requesterId": 2,
+  "categoryId": 2,
+  "relatedSystemId": 4,
+  "summary": "Laptop won't power on after firmware update",
+  "description": "Laptop screen stays black after the scheduled firmware update finished overnight. Power light is on but nothing else responds.",
+  "requestedPriority": "HIGH",
+  "status": "NEW",
+  "createdAt": "2026-08-29T10:15:00.000Z",
+  "updatedAt": "2026-08-29T10:15:00.000Z",
+  "attachments": [
+    {
+      "id": 101,
+      "ticketId": 42,
+      "originalFilename": "screenshot.png",
+      "mimeType": "image/png",
+      "sizeBytes": 245678,
+      "createdAt": "2026-08-29T10:16:00.000Z",
+      "isRemoved": false,
+      "removedAt": null,
+      "removalReason": null
+    }
+  ]
+}
+```
+
+**Worked example — failure (AC-03, cross-Requester access)**
+
+```
+GET /api/tickets/42
+X-Requester-Id: 3
+```
+```json
+404 Not Found
+{ "error": "Not found" }
+```
+(Requester 3 is a valid, active Requester — just not the owner of Ticket
+42 — so the response is indistinguishable from Ticket 42 not existing at
+all, per BR-10/BR-36.)
+
+---
+
+## 7. `POST /api/tickets/:id/attachments`
+
+**Purpose**: upload up to 5 files to an existing owned Ticket in one
+request (FR-09).
+
+**Headers**: `X-Requester-Id` (§0.1); ownership enforced per BR-33 (only
+the owning Requester may add an attachment to their own Ticket).
+
+**Content-Type**: `multipart/form-data`.
+
+**Path params**: `id` — the target Ticket's id.
+
+**Body**: field `files`, 1–5 entries (each an uploaded file).
+
+**Responses**:
+
+| Status | Body | Trigger / BR |
+|---|---|---|
+| 201 | `Attachment[]` (§0.3 representation), one entry per stored file | all files in the batch pass validation and are stored |
+| 400 | `{ "errors": [...] }` | malformed request only: `files` missing/empty, or `:id` is not a valid Ticket-id format. Checked before any file-content validation, since a malformed request can't be counted or inspected |
+| 403 | `{ "error": "Selected Requester is not active" }` | §0.1 |
+| 404 | `{ "error": "Not found" }` | Ticket not found or not owned (BR-10, BR-36) |
+| 409 | `{ "error": "Too many files in this request" }` | more than 5 files in the request (BR-29, AC-17) |
+| 409 | `{ "error": "Attachment limit reached" }` | accepting the batch would push the Ticket's active-attachment count above 5 (BR-28, AC-16) |
+| 415 | `{ "error": "Unsupported file type" }` | first file, in submission order, whose type is not JPG/JPEG/PNG/WEBP/PDF (BR-26, AC-19) |
+| 413 | `{ "error": "File exceeds 5 MB" }` | first file, in submission order, that exceeds 5 MB — only checked once no file has already failed 409/415 (BR-27, AC-18) |
+| 500 | `{ "error": "Unexpected server error" }` | §0.2 |
+
+**Precedence rule** (specification.md §8, exact): among the
+content-validation codes, checks run in the fixed order **409 → 415 →
+413**. The first failing check in that order determines the single
+response status for the whole request. Regardless of which single file
+caused the failure, **none of the files in the batch are stored** (BR-30,
+AC-16, AC-17) — this is the same atomic-batch behavior specification.md
+Assumption 9 applies uniformly to batches of any size ≤5, not only to the
+>5-file wholesale-rejection case.
+
+Full overall check order: **400 (malformed) → 404 (ticket lookup/
+ownership) → 409 → 415 → 413** (Resolved Decision OQ-9, §12) — 404 is
+checked second, after 400 and before 409.
+
+A successful upload also updates the parent Ticket's `updatedAt` (BR-39),
+which is what the My Tickets "Last Updated" column reflects.
+
+**Worked example — success (AC-15)**
+
+```
+POST /api/tickets/42/attachments
+X-Requester-Id: 2
+Content-Type: multipart/form-data; boundary=----X
+
+------X
+Content-Disposition: form-data; name="files"; filename="error-dialog.jpg"
+Content-Type: image/jpeg
+
+<binary>
+------X--
+```
+```json
+201 Created
+[
+  {
+    "id": 102,
+    "ticketId": 42,
+    "originalFilename": "error-dialog.jpg",
+    "mimeType": "image/jpeg",
+    "sizeBytes": 812345,
+    "createdAt": "2026-08-29T11:00:00.000Z",
+    "isRemoved": false,
+    "removedAt": null,
+    "removalReason": null
+  }
+]
+```
+
+**Worked example — failure (AC-17, >5 files, precedence)**
+
+```
+POST /api/tickets/42/attachments
+X-Requester-Id: 2
+Content-Type: multipart/form-data; boundary=----X
+
+(6 files attached, one of which is also oversized and one of which is
+also an unsupported type)
+```
+```json
+409 Conflict
+{ "error": "Too many files in this request" }
+```
+(409 wins over the 415/413 conditions also present in the batch, per the
+fixed 409 → 415 → 413 precedence. No files are stored.)
+
+---
+
+## 8. `GET /api/tickets/:ticketId/attachments/:attachmentId`
+
+**Purpose**: Attachment metadata only, never the file body.
+
+**Headers**: `X-Requester-Id` (§0.1).
+
+**Path params**: `ticketId`, `attachmentId` — integers.
+
+**Responses**:
+
+| Status | Body | Trigger / BR |
+|---|---|---|
+| 200 | Attachment representation (§0.3), including removed-state fields even if removed | found and owned |
+| 403 | `{ "error": "Selected Requester is not active" }` | §0.1 |
+| 404 | `{ "error": "Not found" }` | not found, or not owned by caller (BR-10) |
+| 500 | `{ "error": "Unexpected server error" }` | §0.2 |
+
+**Worked example — success**
+
+```
+GET /api/tickets/42/attachments/101
+X-Requester-Id: 2
+```
+```json
+200 OK
+{
+  "id": 101,
+  "ticketId": 42,
+  "originalFilename": "screenshot.png",
+  "mimeType": "image/png",
+  "sizeBytes": 245678,
+  "createdAt": "2026-08-29T10:16:00.000Z",
+  "isRemoved": false,
+  "removedAt": null,
+  "removalReason": null
+}
+```
+
+**Worked example — failure**
+
+```
+GET /api/tickets/42/attachments/999
+X-Requester-Id: 2
+```
+```json
+404 Not Found
+{ "error": "Not found" }
+```
+
+---
+
+## 9. `GET /api/tickets/:ticketId/attachments/:attachmentId/download`
+
+**Purpose**: stream an active Attachment's file; also used as "preview"
+per BR-35 (opens directly in a new browser tab, no in-app viewer) (FR-10).
+
+**Headers**: `X-Requester-Id` (§0.1).
+
+**Path params**: `ticketId`, `attachmentId` — integers.
+
+**Responses**:
+
+| Status | Body | Trigger / BR |
+|---|---|---|
+| 200 | binary file stream; `Content-Type` set from the stored `mimeType` | attachment found, owned, and active |
+| 403 | `{ "error": "Selected Requester is not active" }` | §0.1 |
+| 404 | `{ "error": "Not found" }` | not found, not owned, **or the attachment is removed** (BR-32, AC-21) |
+| 500 | `{ "error": "Unexpected server error" }` | §0.2 |
+
+A removed Attachment returns 404 here even to its own owning Requester —
+BR-32 states no one can download or preview a removed Attachment.
+
+**Worked example — success**
+
+```
+GET /api/tickets/42/attachments/101/download
+X-Requester-Id: 2
+```
+```
+200 OK
+Content-Type: image/png
+
+<binary file content>
+```
+
+**Worked example — failure (AC-21, removed attachment)**
+
+```
+GET /api/tickets/42/attachments/103/download
+X-Requester-Id: 2
+```
+```json
+404 Not Found
+{ "error": "Not found" }
+```
+(Attachment 103 has been soft-removed; no file content is returned.)
+
+---
+
+## 10. `DELETE /api/tickets/:ticketId/attachments/:attachmentId`
+
+**Purpose**: soft-remove an Attachment (FR-11).
+
+**Headers**: `X-Requester-Id` (§0.1); ownership enforced per BR-33 (only
+the owning Requester may remove an Attachment on their own Ticket).
+
+**Path params**: `ticketId`, `attachmentId` — integers.
+
+**Request body**:
+
+```
+{
+  reason?: string    // optional, ≤200 chars (BR-34)
+}
+```
+
+**Responses**:
+
+| Status | Body | Trigger / BR |
+|---|---|---|
+| 200 | Attachment representation (§0.3) with `isRemoved: true`, `removedAt` set, `removalReason` set (or `null` if omitted) | removed successfully (BR-31, AC-20) |
+| 400 | `{ "errors": [{ "field": "reason", "message": "Reason must be 200 characters or fewer" }] }` | `reason` exceeds 200 characters (BR-34) |
+| 403 | `{ "error": "Selected Requester is not active" }` | §0.1 |
+| 404 | `{ "error": "Not found" }` | not found or not owned (BR-10) |
+| 409 | `{ "error": "Attachment already removed" }` | attachment was already soft-removed |
+| 500 | `{ "error": "Unexpected server error" }` | §0.2 |
+
+Removal is soft: the row is retained with `removedAt` and optional
+`removalReason` set; the underlying file is never deleted from storage
+(BR-31). The Attachment's metadata (filename, size, upload date, removal
+date, and reason if provided) remains visible on Ticket Detail after
+removal (BR-32). Removal also updates the parent Ticket's `updatedAt`
+(BR-39).
+
+**Worked example — success (AC-20)**
+
+```
+DELETE /api/tickets/42/attachments/101
+X-Requester-Id: 2
+Content-Type: application/json
+
+{ "reason": "Duplicate of another attached screenshot" }
+```
+```json
+200 OK
+{
+  "id": 101,
+  "ticketId": 42,
+  "originalFilename": "screenshot.png",
+  "mimeType": "image/png",
+  "sizeBytes": 245678,
+  "createdAt": "2026-08-29T10:16:00.000Z",
+  "isRemoved": true,
+  "removedAt": "2026-08-29T11:30:00.000Z",
+  "removalReason": "Duplicate of another attached screenshot"
+}
+```
+
+**Worked example — failure (double removal)**
+
+```
+DELETE /api/tickets/42/attachments/101
+X-Requester-Id: 2
+Content-Type: application/json
+
+{}
+```
+```json
+409 Conflict
+{ "error": "Attachment already removed" }
+```
+
+---
+
+## 11. HTTP status summary
+
+Reproduced from specification.md §8 for quick reference; not a separate
+rule set.
+
+| Status | Meaning in this API |
+|---|---|
+| 200 | Successful retrieval, or idempotent replay of a create |
+| 201 | Resource created |
+| 400 | Invalid input / field validation failure |
+| 403 | `X-Requester-Id` does not match a currently active Requester |
+| 404 | Resource missing, not owned by the caller, or removed (attachment download) |
+| 409 | State conflict: attachment cap exceeded, >5 files in one request, double-removal |
+| 413 | Uploaded file exceeds 5 MB |
+| 415 | Uploaded file type not permitted |
+| 500 | Unexpected server error; body never leaks internal detail |
+
+---
+
+## 12. Resolved decisions
+
+These nine details were not fixed by the original specification.md.
+Each is now resolved; the answer is applied throughout this document.
+Two (OQ-2, OQ-7) also amend specification.md itself — see that document's
+§8 (`GET /api/tickets` query line) and BR-23 respectively.
+
+- **OQ-1**: The 400 returned when `X-Requester-Id` is missing or
+  non-integer (§0.1) is
+  `{ "errors": [{ "field": "X-Requester-Id", "message": "Missing or invalid requester header" }] }`.
+  Reason: keeps the header check inside the same `{ field, message }`
+  shape already fixed for body validation, just naming the header as the
+  field.
+- **OQ-2**: The `GET /api/tickets` category filter is `categoryId`
+  (integer), not `category`. An invalid or unknown value returns 400 and
+  is added to the endpoint's 400-trigger list alongside `sortBy`,
+  `sortDir`, `requestedPriority`, and `status`. Reason: the underlying
+  column is a foreign-key `categoryId` everywhere else in the contract, and
+  every other filter/sort parameter on this endpoint already 400s on a bad
+  value — `category` was the odd one out.
+- **OQ-3**: One shared Ticket representation is used across
+  `POST /api/tickets`, `GET /api/tickets` list items, and
+  `GET /api/tickets/:id`. Detail adds `attachments: Attachment[]`; list
+  adds nothing. Reason: a Ticket has one server-side shape; diverging it
+  per endpoint would mean maintaining multiple shapes for no behavioral
+  difference.
+- **OQ-4**: `storedFilename` is never returned in any client-facing
+  response. Reason: it is a server-side storage-lookup detail; returning
+  it would expose internal file-storage layout for no client-side use.
+- **OQ-5**: `GET /api/categories` adopts the generic
+  `{ "error": "Unexpected server error" }` 500 wording fixed in §8, rather
+  than keeping its prior implementation-specific text. Reason: one
+  consistent 500 message across the whole API, matching every other
+  endpoint documented here.
+- **OQ-6**: `GET /api/requesters` returns `{ id, name }` only —
+  `email` is not included. Reason: matches the `{ id, name }` convention
+  already fixed for Category/RelatedSystem; the selector dropdown has no
+  use for `email`.
+- **OQ-7**: The `id`-descending tiebreaker applies to every sort on
+  `GET /api/tickets`, not only the default `createdAt` sort. Reason (per
+  the resolution): `status` is single-valued in Lab 2, so every row ties
+  on that sort key, and pagination would be non-deterministic across pages
+  without a universal tiebreaker.
+- **OQ-8**: On `GET /api/tickets`, `page` below 1 clamps to 1; `pageSize`
+  clamps to the nearest allowed value in `{10, 20, 50}`; the response's
+  `page`/`pageSize` fields echo the clamped values actually used, not the
+  values originally requested. Reason: keeps "clamped, not rejected"
+  (BR-24) meaningful — the client can tell what was actually applied
+  instead of the response silently disagreeing with its own request
+  echo.
+- **OQ-9**: On `POST /api/tickets/:id/attachments`, 404 (Ticket not found
+  or not owned) is checked second, after 400 and before 409. Reason: the
+  409 active-attachment-count check needs a resolved, owned Ticket to
+  count against, so ownership must be settled before it can run.

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -1,0 +1,122 @@
+# Peer Review — Lab 2
+
+**Author:** Chanat Dachkumhang (Pan) — GitHub `@Chanat-888`, ID 67070503409
+**Peer reviewer / partner:** Jeerasak Phisawong (Snooker) — GitHub `@ShitheadQuin`, ID 67070503461
+
+Reviews are recorded as they happen, not reconstructed at the end.
+
+---
+
+## 1. Reviews I gave on my partner's PRs
+
+| # | PR | Base | Date | Verdict |
+|---|----|------|------|---------|
+| 1 | [ShitheadQuin/Toktickit#19 — docs: add Lab 2 engineering contract (spec, api, ui, tests)](https://github.com/ShitheadQuin/Toktickit/pull/19) | `lab2-staging` | 2026-08-29 | Request changes → Approved → Merged |
+| 2 | [ShitheadQuin/Toktickit#20 — feat: data model, migration and seed](https://github.com/ShitheadQuin/Toktickit/pull/20) | `lab2-staging` | 2026-08-30 | Request changes → Approved → Merged |
+
+### PR #19 — review comments given
+
+Scope reviewed: `specification.md`, `api-spec.md`, `ui-spec.md`, `tests.md`, `reviewer.md`,
+`ai-use.md` (6 files, +839 lines). Checked against the Lab 2 labsheet.
+
+**Blocking**
+
+1. `api-spec.md` §7 justifies the `X-Requester-Id` header by saying download links sit in
+   `<img>` / `<a>` tags. A browser cannot set a custom header from `<img src>` or `<a href>`,
+   so `GET /api/attachments/:id/download` is unreachable from the UI described in
+   `ui-spec.md` §15. Suggested fix: accept `requesterId` as a query parameter on download
+   only, or fetch the file as a blob.
+2. The Requester field is missing from Create Ticket. Labsheet §4.4 lists it as required, and
+   Part 6 requires evidence that it is populated from the selected Development Requester and
+   that the saved Ticket's `requesterId` matches. Add it to the `ui-spec.md` §8 field order
+   and add an acceptance criterion.
+3. `tests.md` STYLE-01 asserts "required CSS classes", but `ui-spec.md` names no classes.
+   Labsheet §8.8 requires the check to compare against `ui-spec.md`. Add a class-naming table.
+
+**Should fix**
+
+4. `specification.md` §10 Definition of Done omits peer review and visual inspection, both
+   required by labsheet §4.1.
+5. Seed data is unspecified. Labsheet §5.3 requires 4 categories, 6+ related systems,
+   4 active and 1 inactive Requester, and an idempotent seed.
+
+**Minor**
+
+- No FR covers `GET /api/categories` or `GET /api/related-systems`.
+- `specification.md` §11 says the Ticket Number hides the database id, but the `api-spec.md`
+  example pairs `id: 42` with `TKT-2026-000042`.
+
+**Author response (2026-08-29):** Fixed all five items plus both minor points in a follow-up
+commit. Download moved to a query parameter, Requester field and AC-27 added, CSS class table
+added in `ui-spec.md` §18, Definition of Done updated, seed counts specified, FR-17 added,
+§11 Ticket Number wording corrected.
+
+**Re-review (2026-08-29):** Approved and merged into `lab2-staging`. Each change verified on the
+branch before approval.
+
+### PR #20 — review comments given
+
+Scope reviewed: `server/prisma/schema.prisma`, `server/prisma/seed.ts`, and the migration
+`20260829115154_add_lab2_ticketing_models` (3 files, +211 lines). Checked against the merged
+`specification.md` §7 and §11 and labsheet §5.
+
+**Blocking**
+
+1. The migration creates no sequence for the Ticket Number. `specification.md` §11 says the
+   number is generated from a database sequence, and §7 assigns the migration to this Issue.
+   The migration contains only enums, tables, indexes and foreign keys. Either add
+   `CREATE SEQUENCE` here, or state in the PR that Issue #12 adds it in a second migration.
+
+**Minor**
+
+2. The hot query is `WHERE requesterId = ? ORDER BY ticketDate DESC` (BR-10 default sort).
+   A composite `@@index([requesterId, ticketDate])` serves that better than the two separate
+   single-column indexes.
+3. `RelatedSystem` has `createdAt` but no `updatedAt`, while `Requester` and `Ticket` have both.
+   `specification.md` §7 says "timestamps" for it. Consistency point only.
+
+**Verified as correct:** five models, both enums, `CurrentStatus` limited to `NEW`, FK relations
+and unique constraints matching §7, soft-removal fields on `Attachment`, and an idempotent seed
+with 4 Categories, 6 Related Systems, and 4 active + 1 inactive Requester per labsheet §5.3.
+The datasource URL comes from `prisma.config.ts`, which is correct for Prisma 7.
+
+**Author response (2026-08-30):** Added `CREATE SEQUENCE ticket_number_seq` in a second
+migration (`20260830075952_fix_ticket_index_add_sequence`) as raw SQL, since Prisma has no
+standalone sequence type; Issue #13 will read it via `nextval()`. Replaced the two single-column
+`Ticket` indexes with `@@index([requesterId, ticketDate])`. Added `updatedAt` to `RelatedSystem`
+with `@default(now())` so the seeded rows migrate without error. Left `Category` unchanged.
+
+**Re-review (2026-08-30):** Approved and merged into `lab2-staging`. All three changes verified
+on the branch. `Category` staying as-is is acceptable — it comes from Lab 1 and no Lab 2
+behaviour reads its `updatedAt`.
+
+---
+
+## 2. Reviews my partner gave on my PRs
+
+| # | PR | Base | Date | Verdict |
+|---|----|------|------|---------|
+| 1 | [Chanat-888/TokTickIT#13 — docs: add Lab 2 sprint engineering specification](https://github.com/Chanat-888/TokTickIT/pull/13) | `lab2-staging` | 2026-08-29 | Approved → Merged |
+
+### PR #13 — review comments received
+
+**Thread 1 — BR-37 (transition to authentication in Lab 3)**
+
+Jeerasak said BR-37 reads more like a design note than something testable, that no acceptance
+criterion maps to it, and suggested moving it to §11 Assumptions and Decisions.
+
+I disagreed and kept it as a business rule. Labsheet §4.3 lists "the transition to real
+authentication in Lab 3" as a required business-rule area, so moving it to §11 would leave that
+area uncovered. I agreed with his point that no AC should map to it, and committed to listing it
+as intentionally untested in `tests.md`. That commitment is now honoured in `tests.md` §7.
+
+**Thread 2 — BR-38 (Ticket Number generation)**
+
+Jeerasak noted approvingly that BR-38 explains why `MAX(id)+1` is unsafe under concurrency, and
+why insert-and-retry was chosen over a per-year Postgres sequence, rather than just stating the
+rule.
+
+I noted an implementation risk to watch: the retry path must not swallow unrelated database
+errors, so only a unique-constraint violation on `ticketNumber` may trigger a retry.
+
+_Approved and merged into `lab2-staging` after this exchange._

--- a/docs/lab-02/specification.md
+++ b/docs/lab-02/specification.md
@@ -119,8 +119,12 @@ this sprint only, and is explicitly labeled as such everywhere it appears.
 - BR-22 The Ticket list can be filtered by Category, Requested Priority, and
   Current Status.
 - BR-23 The Ticket list can be sorted by Created Date, Summary, Requested
-  Priority, or Current Status; the default sort is Created Date descending with
-  Ticket id descending as a tiebreaker.
+  Priority, or Current Status; every sort applies Ticket id descending as a
+  tiebreaker, and the default sort is Created Date descending. The
+  tiebreaker is universal, not default-only, because Current Status is
+  single-valued in Lab 2, so any sort by Current Status ties on every row;
+  without a universal tiebreaker, pagination over a Current-Status sort
+  would be non-deterministic.
 - BR-24 Pagination is 1-based; default page size is 10; allowed page sizes are
   10, 20, 50; a page beyond the last available page returns an empty result set,
   not an error.
@@ -286,15 +290,17 @@ Headers: `X-Requester-Id`, `Idempotency-Key` (uuid).
 Body: `{ categoryId, relatedSystemId, summary, description, requestedPriority }`.
 - 201 — created: `{ id, ticketNumber, requesterId, categoryId, relatedSystemId, summary, description, requestedPriority, status, createdAt, updatedAt }`.
 - 200 — replay of a previously used `Idempotency-Key`: same shape, no new row created (BR-11).
-- 400 — missing/invalid field, or `categoryId`/`relatedSystemId` not active: `{ errors: [{ field, message }] }`.
+- 400 — missing/invalid field, `categoryId`/`relatedSystemId` not active, or
+  `Idempotency-Key` missing/not a valid UUID: `{ errors: [{ field, message }] }`.
 
 **GET /api/tickets**
-Query: `search`, `category`, `requestedPriority`, `status`, `sortBy`
+Query: `search`, `categoryId`, `requestedPriority`, `status`, `sortBy`
 (`createdAt`|`summary`|`requestedPriority`|`status`), `sortDir` (`asc`|`desc`),
 `page`, `pageSize` (10|20|50).
 - 200 — `{ data: Ticket[], page, pageSize, totalCount, totalPages }`. Out-of-range
   `page`/`pageSize` values are clamped, not rejected.
-- 400 — invalid `sortBy`, `sortDir`, `requestedPriority`, or `status` value.
+- 400 — invalid `categoryId`, `sortBy`, `sortDir`, `requestedPriority`, or
+  `status` value.
 
 **GET /api/tickets/:id**
 - 200 — Ticket fields plus `attachments: Attachment[]` (each including
@@ -333,6 +339,7 @@ regardless of which file caused the failure (BR-30).
 **DELETE /api/tickets/:ticketId/attachments/:attachmentId**
 Body: `{ reason?: string }` (≤200 chars).
 - 200 — updated metadata with `isRemoved: true`, `removedAt`, `removalReason`.
+- 400 — `reason` exceeds 200 characters: `{ errors: [{ field, message }] }`.
 - 404 — not found or not owned.
 - 409 — already removed.
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -415,10 +415,12 @@ the new tests API-58–API-60 (§2.2).
 - **OQ-TEST-1**: The exact 400 response when `Idempotency-Key` is missing
   or malformed on `POST /api/tickets`. **Decision:** 400 with
   `{ errors: [{ "field": "Idempotency-Key", "message": "Missing or invalid
-  idempotency key" }] }`, added to the endpoint's field-validation 400
-  trigger table (api-spec.md §4, specification.md §8). **Reason:** keeps
-  `Idempotency-Key` validation inside the same body-validation shape already
-  used for every other `POST /api/tickets` field, rather than leaving it
+  idempotency key" }] }`, added as a 400 response row in api-spec.md §4,
+  alongside the `X-Requester-Id` header 400 and with the same exact-message
+  pattern (specification.md §8 fixes the condition; api-spec.md fixes the
+  wording). **Reason:** keeps
+  `Idempotency-Key` validation inside the same `{ field, message }` shape
+  already used for every other 400 on this endpoint, rather than leaving it
   undefined.
 - **OQ-TEST-2**: The response when a `DELETE .../attachments/:id` request's
   `reason` exceeds 200 characters. **Decision:** 400 with

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -1,0 +1,436 @@
+# Lab 2 Test Plan
+
+Sources of truth, in this order: `specification.md`, `api-spec.md`, `ui-spec.md`
+(all merged and authoritative). This document does not re-decide anything
+fixed there — it maps FR/BR/AC/UI rules onto concrete, automatable tests.
+No code is included; test files listed below do not exist yet, this is the
+plan that governs what they must contain. Every row's `Final` column is left
+blank — it is filled in once the corresponding test file is written and run,
+matching the evidence format `docs/lab-01/tests.md` used for Lab 1.
+
+---
+
+## 1. Test Strategy
+
+Six test levels, each with its own tool and scope:
+
+| Level | Tool | Scope | Talks to a real DB? |
+|---|---|---|---|
+| Unit | Vitest | Pure functions in isolation — no HTTP, no DOM, no DB | No |
+| API/Integration | Vitest + Supertest | Express routes through Prisma against `toktickit_test` | Yes |
+| UI Component | Vitest + React Testing Library | One component/screen at a time, API calls mocked | No |
+| UI Style | Vitest + React Testing Library | Same as UI Component, but asserts only the exact class names fixed in `ui-spec.md` §19 | No |
+| Responsive | Playwright | Real browser, viewport resizing, screenshot capture | Via a running server/client, not a unit-test DB |
+| E2E | Playwright | Full stack, multi-step user flows, multiple Requesters | Via a running server/client |
+
+**ID scheme**: `UNIT-nn`, `API-nn`, `UI-nn`, `STYLE-nn`, `RESP-nn`, `E2E-nn`,
+each independently numbered.
+
+**File locations.** Server-side files match the four names fixed by the
+labsheet's repository structure exactly (`server/tests/lab-02/*.api.test.ts`,
+one per resource area) plus two unit-test files for pure server logic. On the
+client, component/style/unit tests are placed under `client/tests/lab-02/`,
+mirroring the existing Lab 1 convention (`client/tests/lab-01/App.test.tsx`)
+rather than under `client/src/`, since components live in `client/src/` but
+their tests already live in a parallel `client/tests/` tree in this repo.
+E2E and responsive/visual specs live under `e2e/lab-02/`; the flow spec name
+(`requester-ticket-flow.spec.ts`) is fixed by the labsheet, and a second
+`responsive-visual.spec.ts` is added alongside it to hold the viewport/
+screenshot checks so they aren't mixed into the functional flow file.
+
+**Ownership isolation as a cross-cutting concern.** Rather than re-testing
+the `X-Requester-Id` validation table (api-spec.md §0.1) on every single
+endpoint, it is verified in full on a representative pair
+(`POST /api/tickets`, `GET /api/tickets/:id`) since every other endpoint
+applies the identical shared check; endpoint-specific tests then assume that
+check already passed and focus on what's unique to that route.
+
+**Database isolation.** Every API/integration test runs against a dedicated
+`toktickit_test` database, migrated once in global setup and truncated
+between tests — see §5. No test ever runs against the development database.
+
+**What "boundaries" means here.** Every length/count limit in
+`specification.md` §5 (BR-15, BR-16, BR-24, BR-27, BR-28, BR-29, BR-34) gets
+at least one test at its edge value (e.g. summary at exactly 5 and exactly
+120 characters), not only comfortably-inside and comfortably-outside values.
+
+---
+
+## 2. Planned Tests
+
+### 2.1 Unit
+
+| Test ID | Type | Requirement/AC | What It Tests | Expected Result | Automated Test File | Final |
+|---|---|---|---|---|---|---|
+| UNIT-01 | Unit | BR-38 | Candidate `TKT-YYYY-NNNNNN` generation from a given year and count | Zero-padded 6-digit sequence, correct year | `server/tests/lab-02/ticket-number.unit.test.ts` | |
+| UNIT-02 | Unit | BR-38 | Retry loop on a mocked unique-constraint violation | Retries up to 5 times, then gives up rather than looping forever | `server/tests/lab-02/ticket-number.unit.test.ts` | |
+| UNIT-03 | Unit | BR-14 | Summary/Description are trimmed before length validation | `"  hi  "` is measured as length 2, not 6 | `server/tests/lab-02/ticket-validation.unit.test.ts` | |
+| UNIT-04 | Unit | BR-15 | Summary length boundary | 4 chars fails, 5 passes, 120 passes, 121 fails | `server/tests/lab-02/ticket-validation.unit.test.ts` | |
+| UNIT-05 | Unit | BR-16 | Description length boundary | 9 chars fails, 10 passes, 2000 passes, 2001 fails | `server/tests/lab-02/ticket-validation.unit.test.ts` | |
+| UNIT-06 | Unit | AC-18, BR-27 | Client-side file-size check | Files >5 MB flagged, ≤5 MB accepted | `client/tests/lab-02/attachment-validation.unit.test.ts` | |
+| UNIT-07 | Unit | AC-19, BR-26 | Client-side file-type check | JPG/JPEG/PNG/WEBP/PDF accepted, anything else flagged | `client/tests/lab-02/attachment-validation.unit.test.ts` | |
+| UNIT-08 | Unit | BR-28, BR-29 | Client-side active-count check (picker convenience, not authoritative) | Adding a file that would push the selection over 5 is rejected client-side | `client/tests/lab-02/attachment-validation.unit.test.ts` | |
+| UNIT-09 | Unit | ui-spec.md §13.2 (OQ-UI-2) | Default `sortDir` lookup per `sortBy` column | `desc` for `createdAt`, `asc` for `summary`, `desc` for `requestedPriority`, `desc` for `status` | `client/tests/lab-02/sort-defaults.unit.test.ts` | |
+| UNIT-10 | Unit | BR-11, BR-13 | A fresh `Idempotency-Key` (UUID v4 shape) is generated per new Create-Ticket attempt | Two independent submissions get two different keys | `client/tests/lab-02/idempotency-key.unit.test.ts` | |
+
+### 2.2 API/Integration
+
+| Test ID | Type | Requirement/AC | What It Tests | Expected Result | Automated Test File | Final |
+|---|---|---|---|---|---|---|
+| API-01 | API/Integration | FR-02, BR-17 | `GET /api/categories` | Active Categories only, ordered by `id` | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-02 | API/Integration | FR-02, BR-17 | `GET /api/related-systems` | Active Related Systems only, ordered by `id` | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-03 | API/Integration | AC-26, BR-05, BR-06 | `GET /api/requesters` | Active Requesters only; seeded inactive Requester excluded | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-04 | API/Integration | AC-01, AC-27, BR-01, BR-02, BR-04 | `POST /api/tickets` valid body | 201, `ticketNumber` matches `TKT-YYYY-NNNNNN`, `status: "NEW"`, `requesterId` equals the `X-Requester-Id` sent | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-05 | API/Integration | api-spec.md §0.1 | `POST /api/tickets` missing `X-Requester-Id` | 400, `field: "X-Requester-Id"` | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-06 | API/Integration | api-spec.md §0.1 | `POST /api/tickets` header valid integer, not an active Requester | 403, `"Selected Requester is not active"` | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-07 | API/Integration | AC-04, BR-15, BR-19 | `POST /api/tickets` empty Summary | 400 field error on `summary`; no Ticket row created | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-08 | API/Integration | BR-16 | `POST /api/tickets` Description at 9 chars (below minimum) | 400 field error on `description` | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-09 | API/Integration | AC-07, BR-17 | `POST /api/tickets` `categoryId` referencing a deactivated Category | 400 field error on `categoryId` | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-10 | API/Integration | BR-17 | `POST /api/tickets` `relatedSystemId` referencing an inactive/nonexistent row | 400 field error on `relatedSystemId` | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-11 | API/Integration | BR-18 | `POST /api/tickets` `requestedPriority: "URGENT"` | 400 field error on `requestedPriority` | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-12 | API/Integration | AC-05, BR-11, BR-12 | `POST /api/tickets` repeated `Idempotency-Key`, same Requester | 200, identical `id`/`ticketNumber` to the first response, no second row | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-13 | API/Integration | BR-12 | `POST /api/tickets` same `Idempotency-Key`, different Requester | 201, a distinct second Ticket is created (key scoping is per-Requester) | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-14 | API/Integration | AC-06, BR-11, BR-12 | Two concurrent `POST /api/tickets` requests sharing one `Idempotency-Key` | Exactly one Ticket row exists afterward | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-15 | API/Integration | BR-15, BR-16 | `POST /api/tickets` Summary at 121 chars, Description at 2001 chars | 400 field errors on both, upper boundary | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-16 | API/Integration | api-spec.md §0.1 | `GET /api/tickets` missing `X-Requester-Id` | 400 | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-17 | API/Integration | FR-04, BR-09 | `GET /api/tickets` Requester A vs. Requester B | Requester A never sees Requester B's Tickets or vice versa | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-18 | API/Integration | AC-09, BR-24 | `GET /api/tickets` default page/pageSize, 25-Ticket Requester | 10 items, `page: 1`, `totalCount: 25`, `totalPages: 3` | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-19 | API/Integration | BR-24 | `GET /api/tickets?page=2` and `page=3` on the same Requester | Page 2 returns the next 10, page 3 returns the remaining 5 | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-20 | API/Integration | BR-24 | `GET /api/tickets?page=99` (beyond last page) | 200, empty `data` array, not an error | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-21 | API/Integration | BR-24, api-spec.md §12 OQ-8 | `GET /api/tickets?pageSize=999` | Clamps to 50; response echoes `pageSize: 50` | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-22 | API/Integration | BR-24, api-spec.md §12 OQ-8 | `GET /api/tickets?page=0` | Clamps to 1; response echoes `page: 1` | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-23 | API/Integration | AC-10, BR-21 | `GET /api/tickets?search=<ticket-number-prefix>` | Only Tickets whose number starts with the prefix | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-24 | API/Integration | BR-21 | `GET /api/tickets?search=<summary-substring>` in mixed case | Matches case-insensitively as a substring of Summary | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-25 | API/Integration | AC-11, BR-22 | `GET /api/tickets?categoryId=<id>` | Only Tickets in that Category | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-26 | API/Integration | BR-22 | `GET /api/tickets?requestedPriority=HIGH` | Only `HIGH` Tickets | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-27 | API/Integration | api-spec.md §12 OQ-2 | `GET /api/tickets?categoryId=<unknown-id>` | 400 | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-28 | API/Integration | api-spec.md §5 | `GET /api/tickets` invalid `sortBy`, invalid `sortDir`, `status=RESOLVED` | 400 for each | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-29 | API/Integration | AC-12 | `GET /api/tickets?sortBy=requestedPriority` at `sortDir=desc` then `sortDir=asc` | HIGH-first ordering, then LOW-first ordering | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-30 | API/Integration | BR-23, api-spec.md §12 OQ-7 | Default sort with two Tickets sharing a `createdAt` | Tiebreak by `id` descending, deterministic across repeated requests | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-31 | API/Integration | AC-13, BR-25 | `GET /api/tickets` for the seeded zero-Ticket Requester | `data: []`, `totalCount: 0` | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-32 | API/Integration | AC-14, BR-25 | `GET /api/tickets` with a filter matching nothing, on a Requester whose unfiltered `totalCount` is > 0 | Filtered `data: []` while unfiltered request for the same Requester is non-empty | `server/tests/lab-02/my-tickets.api.test.ts` | |
+| API-33 | API/Integration | FR-08 | `GET /api/tickets/:id` owned | 200, Ticket representation plus `attachments: []` | `server/tests/lab-02/ticket-detail.api.test.ts` | |
+| API-34 | API/Integration | AC-03, BR-10, BR-36 | `GET /api/tickets/:id` owned by a different Requester | 404, `"Not found"` | `server/tests/lab-02/ticket-detail.api.test.ts` | |
+| API-35 | API/Integration | BR-36 | `GET /api/tickets/:id` nonexistent id | 404, body byte-identical to API-34's | `server/tests/lab-02/ticket-detail.api.test.ts` | |
+| API-36 | API/Integration | api-spec.md §0.1 | `GET /api/tickets/:id` missing `X-Requester-Id` | 400 | `server/tests/lab-02/ticket-detail.api.test.ts` | |
+| API-37 | API/Integration | api-spec.md §0.1 | `GET /api/tickets/:id` header not an active Requester | 403 | `server/tests/lab-02/ticket-detail.api.test.ts` | |
+| API-38 | API/Integration | AC-15, BR-39 | `POST /api/tickets/:id/attachments` 1 valid file | 201, `isRemoved: false`; parent Ticket's `updatedAt` advances | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-39 | API/Integration | AC-16, BR-28 | `POST /api/tickets/:id/attachments` on a Ticket already at 5 active, +1 file | 409 `"Attachment limit reached"`; the existing 5 are unchanged | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-40 | API/Integration | AC-17, BR-29 | `POST /api/tickets/:id/attachments` 6 files in one request | 409 `"Too many files in this request"`; none of the 6 stored | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-41 | API/Integration | AC-19, BR-26 | `POST /api/tickets/:id/attachments` unsupported file type | 415 `"Unsupported file type"`; none stored | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-42 | API/Integration | BR-27 | `POST /api/tickets/:id/attachments` file >5 MB | 413 `"File exceeds 5 MB"`; none stored | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-43 | API/Integration | api-spec.md §7 precedence rule | Batch that is simultaneously >5 files, oversized, and wrong-typed | 409 wins (409 → 415 → 413 precedence); none stored | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-44 | API/Integration | BR-30, specification.md Assumption 9 | Batch of ≤5 files where exactly one has a bad type | Whole batch rejected (415); none stored, including the otherwise-valid files | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-45 | API/Integration | api-spec.md §7 | `POST /api/tickets/:id/attachments` with the `files` field missing/empty | 400, checked before the ownership/count checks | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-46 | API/Integration | api-spec.md §12 OQ-9 | `POST /api/tickets/:id/attachments` to a nonexistent/not-owned Ticket | 404, checked after 400 and before 409 | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-47 | API/Integration | api-spec.md §8 | `GET /api/tickets/:ticketId/attachments/:attachmentId` | 200, metadata only, includes `isRemoved`/`removedAt`/`removalReason` | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-48 | API/Integration | BR-10 | `GET /api/tickets/:ticketId/attachments/:attachmentId` not found/not owned | 404 | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-49 | API/Integration | FR-10, BR-35 | `GET .../download` on an active attachment | 200, binary stream, `Content-Type` from stored `mimeType` | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-50 | API/Integration | AC-21, BR-32 | `GET .../download` on a removed attachment, requested by its own owner | 404, no file content | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-51 | API/Integration | BR-10 | `GET .../download` not owned | 404 | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-52 | API/Integration | AC-20, BR-31, BR-32 | `DELETE .../attachments/:id` with a reason | 200, `isRemoved: true`, `removedAt` set, `removalReason` stored; metadata still readable via GET | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-53 | API/Integration | BR-34 | `DELETE .../attachments/:id` with no `reason` | 200, `removalReason: null` | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-54 | API/Integration | BR-34 | `DELETE .../attachments/:id` with `reason` at exactly 200 chars | 200, succeeds (upper boundary) | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-55 | API/Integration | api-spec.md §10 | `DELETE .../attachments/:id` already removed | 409 `"Attachment already removed"` | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-56 | API/Integration | BR-10 | `DELETE .../attachments/:id` not owned/not found | 404 | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-57 | API/Integration | AC-08, BR-20 | `POST /api/tickets` succeeds, then its only attachment upload fails (oversized) | Ticket is retained and still fetchable via `GET /api/tickets/:id`; the failed attachment is not stored | `server/tests/lab-02/attachments.api.test.ts` | |
+| API-58 | API/Integration | BR-11 (§8 OQ-TEST-1) | `POST /api/tickets` missing `Idempotency-Key` header | 400, `field: "Idempotency-Key"`, `"Missing or invalid idempotency key"`; no Ticket created | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-59 | API/Integration | BR-11 (§8 OQ-TEST-1) | `POST /api/tickets` `Idempotency-Key` present but not a valid UUID (e.g. `"abc"`) | 400, `field: "Idempotency-Key"`, `"Missing or invalid idempotency key"`; no Ticket created | `server/tests/lab-02/create-ticket.api.test.ts` | |
+| API-60 | API/Integration | BR-34 (§8 OQ-TEST-2) | `DELETE .../attachments/:id` with `reason` at 201 chars (one over the boundary) | 400, `field: "reason"`, `"Reason must be 200 characters or fewer"`; attachment not removed | `server/tests/lab-02/attachments.api.test.ts` | |
+
+### 2.3 UI Component
+
+| Test ID | Type | Requirement/AC | What It Tests | Expected Result | Automated Test File | Final |
+|---|---|---|---|---|---|---|
+| UI-01 | UI Component | AC-26 | Requester Selection dropdown, mocked active-only response | Only active Requesters render as options | `client/tests/lab-02/RequesterSelect.test.tsx` | |
+| UI-02 | UI Component | ui-spec.md §11 | Continue button state | Disabled with no selection; enabled once one is chosen | `client/tests/lab-02/RequesterSelect.test.tsx` | |
+| UI-03 | UI Component | BR-07 | Continue click | Writes the selection to `sessionStorage`, navigates to My Tickets | `client/tests/lab-02/RequesterSelect.test.tsx` | |
+| UI-04 | UI Component | ui-spec.md §11 | Loading state | Spinner + "Loading Requesters…" while the request is pending | `client/tests/lab-02/RequesterSelect.test.tsx` | |
+| UI-05 | UI Component | ui-spec.md §11 | Empty state, API returns `[]` | "No active Development Requesters are available." message; Continue stays disabled | `client/tests/lab-02/RequesterSelect.test.tsx` | |
+| UI-06 | UI Component | ui-spec.md §11 | Failure state, API rejects | `.state-banner--error` with "Couldn't load Development Requesters." and a Retry button | `client/tests/lab-02/RequesterSelect.test.tsx` | |
+| UI-07 | UI Component | AC-27 | Create Ticket initial render | Ticket Number placeholder, today's Date, Requester name — all read-only | `client/tests/lab-02/CreateTicketForm.test.tsx` | |
+| UI-08 | UI Component | AC-04 | Submit with empty Summary | Inline message renders under the field; no API request is sent | `client/tests/lab-02/CreateTicketForm.test.tsx` | |
+| UI-09 | UI Component | BR-19 | 400 response from the server | Already-entered field values and selected attachment chips are preserved, not cleared | `client/tests/lab-02/CreateTicketForm.test.tsx` | |
+| UI-10 | UI Component | AC-06, BR-13 | Submit clicked twice quickly | Busy style + "Submitting…" after the first click; the second click is a no-op | `client/tests/lab-02/CreateTicketForm.test.tsx` | |
+| UI-11 | UI Component | AC-23 | Network/API failure on submit | Failure state renders; entered field values are preserved | `client/tests/lab-02/CreateTicketForm.test.tsx` | |
+| UI-12 | UI Component | AC-01 | Successful creation | Ticket Number and a "View Ticket" link render | `client/tests/lab-02/CreateTicketForm.test.tsx` | |
+| UI-13 | UI Component | AC-08, BR-20 | Ticket created, attachment upload failed | Success sub-state: Ticket Number still shown, plus a Warning-token banner linking to Ticket Detail | `client/tests/lab-02/CreateTicketForm.test.tsx` | |
+| UI-14 | UI Component | AC-18 | Selecting a file >5 MB | Invalid chip with "File exceeds 5 MB"; excluded from the submit payload | `client/tests/lab-02/AttachmentPicker.test.tsx` | |
+| UI-15 | UI Component | AC-19 | Selecting an unsupported file type | Invalid chip with "Unsupported file type"; excluded from the payload | `client/tests/lab-02/AttachmentPicker.test.tsx` | |
+| UI-16 | UI Component | BR-28, BR-29 | Selecting a 6th file when 5 are already selected | Batch-level banner "Up to 5 attachments allowed"; the newest addition is rejected | `client/tests/lab-02/AttachmentPicker.test.tsx` | |
+| UI-17 | UI Component | ui-spec.md §6 | Chip "✕" control | Removes that file from the selection | `client/tests/lab-02/AttachmentPicker.test.tsx` | |
+| UI-18 | UI Component | ui-spec.md §7 | My Tickets loading state | Skeleton rows/cards render while the GET is in flight | `client/tests/lab-02/MyTickets.test.tsx` | |
+| UI-19 | UI Component | ui-spec.md §13.2 | Populated list, desktop | All 7 columns render with correctly mapped values | `client/tests/lab-02/MyTickets.test.tsx` | |
+| UI-20 | UI Component | AC-13, BR-25 | Empty state | "No tickets yet" heading + Create Ticket action; toolbar hidden | `client/tests/lab-02/MyTickets.test.tsx` | |
+| UI-21 | UI Component | AC-14, BR-25 | No-results state | "No tickets match your search" heading + enabled Clear Filters; toolbar stays visible | `client/tests/lab-02/MyTickets.test.tsx` | |
+| UI-22 | UI Component | ui-spec.md §13.1 | Clear Filters enable/disable | Disabled with no active search/filter; enabled once one is applied | `client/tests/lab-02/MyTickets.test.tsx` | |
+| UI-23 | UI Component | ui-spec.md §13.2 | Clicking a sortable column header | Toggles `sortDir`; the ▲/▼ glyph updates to match | `client/tests/lab-02/MyTickets.test.tsx` | |
+| UI-24 | UI Component | ui-spec.md §13.5 (OQ-UI-3) | Page-size select | Changing it updates `pageSize` and resets to page 1 | `client/tests/lab-02/MyTickets.test.tsx` | |
+| UI-25 | UI Component | ui-spec.md §7 | My Tickets failure state | `.state-banner--error` with a Retry action | `client/tests/lab-02/MyTickets.test.tsx` | |
+| UI-26 | UI Component | FR-08 | Ticket Detail loaded state | Read-only header fields + Attachments panel; Priority/Status render as badges | `client/tests/lab-02/TicketDetail.test.tsx` | |
+| UI-27 | UI Component | AC-03, BR-36 | Ticket Detail 404 (missing vs. cross-Requester) | Identically-worded not-found panel with a "Back to My Tickets" link in both cases | `client/tests/lab-02/TicketDetail.test.tsx` | |
+| UI-28 | UI Component | AC-20, BR-34 | Remove Attachment | Confirmation panel with optional Reason field; only Confirm calls the DELETE | `client/tests/lab-02/TicketDetail.test.tsx` | |
+| UI-29 | UI Component | ui-spec.md §17 | Removed attachment row | Muted styling, "Removed" label + date/reason; no Preview/Download/Remove controls | `client/tests/lab-02/TicketDetail.test.tsx` | |
+| UI-30 | UI Component | ui-spec.md §17 | Preview/Download click that resolves 404 | Transient inline error; the action is disabled until the list refreshes | `client/tests/lab-02/TicketDetail.test.tsx` | |
+| UI-31 | UI Component | ui-spec.md §7 | Ticket Detail loading state | Skeleton renders before data resolves | `client/tests/lab-02/TicketDetail.test.tsx` | |
+| UI-32 | UI Component | BR-35 | Preview action | Opens the download URL in a new browser tab, not an in-app viewer | `client/tests/lab-02/TicketDetail.test.tsx` | |
+| UI-33 | UI Component | ui-spec.md §10 | Active nav link | Carries the underline styling class and `aria-current="page"` together | `client/tests/lab-02/AppShell.test.tsx` | |
+| UI-34 | UI Component | ui-spec.md §10 | Change Requester click | Clears `sessionStorage` and routes to Requester Selection with no confirmation step | `client/tests/lab-02/AppShell.test.tsx` | |
+
+### 2.4 UI Style
+
+Every row asserts on the exact class names fixed in `ui-spec.md` §19 — none
+of the classes below are invented for this document.
+
+| Test ID | Type | Requirement/AC | What It Tests | Expected Result | Automated Test File | Final |
+|---|---|---|---|---|---|---|
+| STYLE-01 | UI Style | ui-spec.md §3, §19 | Read-only fields (Ticket Number, Date, Requester, Current Status) | `field__control--readonly` class present | `client/tests/lab-02/style/field-states.style.test.tsx` | |
+| STYLE-02 | UI Style | ui-spec.md §4, §19 | An invalid field after validation failure | `field__control--invalid` on the control, `field__message field__message--error` on its message | `client/tests/lab-02/style/field-states.style.test.tsx` | |
+| STYLE-03 | UI Style | ui-spec.md §3, §19 | A disabled control | `field__control--disabled` class present | `client/tests/lab-02/style/field-states.style.test.tsx` | |
+| STYLE-04 | UI Style | ui-spec.md §4, §19 | A required field's label | `field__required-marker` span renders the asterisk | `client/tests/lab-02/style/field-states.style.test.tsx` | |
+| STYLE-05 | UI Style | ui-spec.md §5, §19 | Each button tier | `btn--primary` / `btn--secondary` / `btn--tertiary` / `btn--destructive` applied correctly per tier | `client/tests/lab-02/style/buttons.style.test.tsx` | |
+| STYLE-06 | UI Style | ui-spec.md §5, §19 | Submit while a request is pending | `btn--busy` class plus a `btn__spinner` element | `client/tests/lab-02/style/buttons.style.test.tsx` | |
+| STYLE-07 | UI Style | ui-spec.md §14.1, §19 | Requested Priority badge per value | `badge--priority-low` / `-medium` / `-high` render for `LOW`/`MEDIUM`/`HIGH` | `client/tests/lab-02/style/badges.style.test.tsx` | |
+| STYLE-08 | UI Style | ui-spec.md §14.2, §19 | Current Status badge | `badge--status-new` renders for `NEW` | `client/tests/lab-02/style/badges.style.test.tsx` | |
+| STYLE-09 | UI Style | ui-spec.md §6, §19 | Attachment picker elements | `attachment-picker__dropzone`, `__chip`, `__chip--invalid`, `__chip-remove`, `__error` all present as expected | `client/tests/lab-02/style/attachment-picker.style.test.tsx` | |
+| STYLE-10 | UI Style | ui-spec.md §17, §19 | Attachment row states | `attachment-item--active` / `--uploading` / `--removed` / `--unavailable` applied per state | `client/tests/lab-02/style/attachment-list.style.test.tsx` | |
+| STYLE-11 | UI Style | ui-spec.md §7, §19 | Every screen state | `state-banner--loading` / `--empty` / `--no-results` / `--error` / `--success` / `--warning` each render for their corresponding condition | `client/tests/lab-02/style/state-banners.style.test.tsx` | |
+| STYLE-12 | UI Style | ui-spec.md §13.1, §19 | My Tickets toolbar controls | `ticket-toolbar__search`, `__filter`, `__page-size`, `__clear-filters-btn` all present | `client/tests/lab-02/style/my-tickets-toolbar.style.test.tsx` | |
+| STYLE-13 | UI Style | ui-spec.md §13.2, §19 | Sortable column header | `ticket-table__header--sortable` and `ticket-table__sort-icon` present | `client/tests/lab-02/style/my-tickets-toolbar.style.test.tsx` | |
+| STYLE-14 | UI Style | ui-spec.md §13.5, §19 | Pagination controls | `pagination__page-btn--active` on the current page; `pagination__prev` / `__next` present | `client/tests/lab-02/style/my-tickets-toolbar.style.test.tsx` | |
+| STYLE-15 | UI Style | ui-spec.md §13.3, §19 | Mobile card view (<768px) | `ticket-card`, `ticket-card__priority-badge`, `ticket-card__status-badge` present | `client/tests/lab-02/style/my-tickets-toolbar.style.test.tsx` | |
+| STYLE-16 | UI Style | ui-spec.md §10, §19 | App shell nav/controls | `app-shell__nav-link--active`, `app-shell__change-requester-btn`, `app-shell__mobile-toggle` present | `client/tests/lab-02/style/app-shell.style.test.tsx` | |
+
+### 2.5 Responsive
+
+| Test ID | Type | Requirement/AC | What It Tests | Expected Result | Automated Test File | Final |
+|---|---|---|---|---|---|---|
+| RESP-01 | Responsive | AC-24 | My Tickets at <768px | `.ticket-card` stacked cards render, no `.ticket-table`, no horizontal page scroll | `e2e/lab-02/responsive-visual.spec.ts` | |
+| RESP-02 | Responsive | ui-spec.md §8 | My Tickets at 768–991px | Table renders with narrower columns; Category may abbreviate | `e2e/lab-02/responsive-visual.spec.ts` | |
+| RESP-03 | Responsive | ui-spec.md §8 | My Tickets at ≥992px | Full 7-column table renders | `e2e/lab-02/responsive-visual.spec.ts` | |
+| RESP-04 | Responsive | ui-spec.md §8 | Create Ticket across breakpoints | Two-column grid on desktop; one column with Attachments below the main fields on mobile | `e2e/lab-02/responsive-visual.spec.ts` | |
+| RESP-05 | Responsive | ui-spec.md §8, §10 | App shell at <768px | Nav + Requester display collapse into `.app-shell__mobile-toggle`; opening it reveals a stacked full-width menu | `e2e/lab-02/responsive-visual.spec.ts` | |
+| RESP-06 | Responsive | ui-spec.md §8 | Ticket Detail header grid | 4 columns desktop, 2 columns tablet, 1 column mobile | `e2e/lab-02/responsive-visual.spec.ts` | |
+| RESP-07 | Responsive | ui-spec.md §18, specification.md §10 | Screenshot capture | One screenshot captured at every path fixed in `ui-spec.md` §18, at every listed viewport | `e2e/lab-02/responsive-visual.spec.ts` | |
+
+### 2.6 E2E
+
+| Test ID | Type | Requirement/AC | What It Tests | Expected Result | Automated Test File | Final |
+|---|---|---|---|---|---|---|
+| E2E-01 | E2E | AC-01, AC-15, AC-27 | Full happy path | Select Requester → Create Ticket with 1 attachment → success shows Ticket Number → View Ticket → Ticket Detail shows matching data and the active attachment | `e2e/lab-02/requester-ticket-flow.spec.ts` | |
+| E2E-02 | E2E | AC-02 | Opening My Tickets with no Requester selected | Redirects to the Requester Selection screen | `e2e/lab-02/requester-ticket-flow.spec.ts` | |
+| E2E-03 | E2E | AC-04 | Submitting Create Ticket with invalid data | Inline validation renders; the form is not navigated away from | `e2e/lab-02/requester-ticket-flow.spec.ts` | |
+| E2E-04 | E2E | AC-09, AC-10, AC-11, AC-12 | My Tickets search/filter/sort/paginate against the seeded ~25-Ticket Requester | Result sets update correctly end-to-end through the real API | `e2e/lab-02/requester-ticket-flow.spec.ts` | |
+| E2E-05 | E2E | AC-20 | Ticket Detail: add then remove (with reason) an attachment | Row updates to the removed state in place, no page reload | `e2e/lab-02/requester-ticket-flow.spec.ts` | |
+| E2E-06 | E2E | AC-22, BR-08 | Change Requester mid-session, A → B | Requester A's Tickets disappear; Requester B's own Tickets load | `e2e/lab-02/requester-ticket-flow.spec.ts` | |
+| E2E-07 | E2E | AC-25 | Keyboard-only navigation of Requester Selection | Dropdown and Continue reachable/operable via Tab/Enter, with a visible focus indicator at each stop | `e2e/lab-02/requester-ticket-flow.spec.ts` | |
+| E2E-08 | E2E | AC-03 | Requester B opens Requester A's Ticket Detail URL directly | Not-found panel renders, same as a nonexistent Ticket | `e2e/lab-02/requester-ticket-flow.spec.ts` | |
+
+---
+
+## 3. Acceptance-Criterion Traceability
+
+Every AC-01 through AC-27 maps to at least one test below.
+
+| AC | Tests |
+|---|---|
+| AC-01 | API-04, UI-12, E2E-01 |
+| AC-02 | E2E-02 |
+| AC-03 | API-34, API-35, UI-27, E2E-08 |
+| AC-04 | API-07, UI-08, E2E-03 |
+| AC-05 | API-12 |
+| AC-06 | API-14, UI-10 |
+| AC-07 | API-09 |
+| AC-08 | API-57, UI-13 |
+| AC-09 | API-18, E2E-04 |
+| AC-10 | API-23, E2E-04 |
+| AC-11 | API-25, E2E-04 |
+| AC-12 | API-29, E2E-04 |
+| AC-13 | API-31, UI-20 |
+| AC-14 | API-32, UI-21 |
+| AC-15 | API-38, E2E-01 |
+| AC-16 | API-39 |
+| AC-17 | API-40 |
+| AC-18 | UNIT-06, UI-14 |
+| AC-19 | UNIT-07, UI-15, API-41 |
+| AC-20 | API-52, UI-28, E2E-05 |
+| AC-21 | API-50 |
+| AC-22 | E2E-06 |
+| AC-23 | UI-09, UI-11 |
+| AC-24 | RESP-01 |
+| AC-25 | E2E-07 |
+| AC-26 | API-03, UI-01 |
+| AC-27 | API-04, UI-07, E2E-01 |
+
+---
+
+## 4. Responsive and Visual Checklist
+
+Checked at the three breakpoints fixed by labsheet §8.7 / `ui-spec.md` §8.
+Each row's screenshot path is fixed by `ui-spec.md` §18; `{viewport}`
+expands to `desktop`, `tablet`, or `mobile`.
+
+| Screen | Desktop (≥992px) | Tablet (768–991px) | Mobile (<768px) | Screenshot path(s) | Verified |
+|---|---|---|---|---|---|
+| Requester Selection | loading, loaded, empty, failure | — | — | `create-ticket/requester-select-{state}-desktop.png` | |
+| Create Ticket | 2-column grid | 2-column, Summary/Description full-width rows | 1 column, Attachments below main fields | `create-ticket/create-ticket-initial-{viewport}.png` (+ validation/submitting/success/failure/invalid-attachment, desktop only) | |
+| My Tickets | 7-column table | table, narrower columns, Category may abbreviate | `.ticket-card` stacked cards, no horizontal scroll | `my-tickets/my-tickets-list-{viewport}.png` (+ loading/empty/no-results/failure/requester-switch, desktop only) | |
+| Ticket Detail | 4-column header grid | 2-column header grid | 1-column header, Attachments always full-width | `ticket-detail/ticket-detail-loaded-{viewport}.png` (+ removed-attachment/remove-confirm/not-found, desktop only) | |
+| App shell | full horizontal nav | full horizontal nav | hamburger toggle, stacked full-width menu | covered within each screen's own screenshots above | |
+
+Non-viewport visual checks (all asserted via `RESP-*`/`STYLE-*` and manually
+reviewed against the screenshots above, per specification.md §10's "visually
+verified against Playwright screenshots, not personal memory"):
+
+- [ ] No clipped labels, overlapping messages, hidden buttons, or unreadable
+      attachment names at any of the three breakpoints (labsheet §8.7).
+- [ ] Read-only vs. editable field styling matches `ui-spec.md` §3 at every
+      breakpoint.
+- [ ] Badge rules (§14) — icon + colour + text, never colour alone.
+- [ ] Busy Submit state (§5) is visible and legible at every breakpoint.
+- [ ] Focus-visible outline (§3) is visible on every interactive control
+      reached via keyboard.
+
+---
+
+## 5. Test Commands
+
+### 5.1 One-time `toktickit_test` database setup
+
+```
+psql -U toktickit -h localhost -c "CREATE DATABASE toktickit_test;"
+```
+
+`server/.env.test` (not committed) points at it, mirroring `.env.example`'s
+convention:
+
+```
+DATABASE_URL="postgresql://toktickit:toktickit@localhost:5432/toktickit_test?schema=public"
+```
+
+### 5.2 Migration in global setup
+
+A `server/tests/globalSetup.ts`, referenced from `server/vitest.config.ts`
+(`test.globalSetup`), loads `.env.test` and runs the migration exactly once
+before any test file executes:
+
+```
+prisma migrate deploy --schema=prisma/schema.prisma
+```
+
+This never touches the development database, since `.env.test` — not
+`.env` — supplies `DATABASE_URL` for the whole test run.
+
+### 5.3 Truncation between tests
+
+A `beforeEach`/`afterEach` hook (`server/tests/setup.ts`, wired via
+`test.setupFiles`) truncates every application table and restarts identity
+sequences, so each test starts from a known-empty state and seeds only the
+fixtures it needs:
+
+```sql
+TRUNCATE TABLE "Attachment", "Ticket", "RequesterUser", "RelatedSystem", "Category"
+RESTART IDENTITY CASCADE;
+```
+
+### 5.4 Running each suite
+
+```
+cd server && npm test        # Unit + API/Integration (Vitest + Supertest)
+cd client && npm test        # UI Component + UI Style (Vitest + RTL, jsdom, no DB/network)
+cd e2e && npx playwright test   # Responsive + E2E (Playwright, real browser)
+```
+
+The E2E/Responsive suite requires the server and client dev servers running
+against a seeded database (`npm run prisma:seed` produces the ~25/~5/0
+distribution specification.md §7 describes) — not `toktickit_test`, since
+that database is truncated between every Vitest test and would never hold
+data long enough for Playwright to exercise it.
+
+---
+
+## 6. Final Results
+
+Not yet run. This plan was written before the Lab 2 client/server
+implementation, following the same spec-first order as
+`specification.md` → `api-spec.md` → `ui-spec.md` → this document. Once the
+test files above exist and the full suite passes with zero skipped/todo
+tests (specification.md §10 Definition of Done), this section is replaced
+with the actual command output for each of the four `npm test`/
+`npx playwright test` runs — in the same format as `docs/lab-01/tests.md`'s
+"Passing runs" section — and every row's `Final` column above is filled in
+(pass/fail, not left blank).
+
+---
+
+## 7. Known Limitations or Deferred Tests
+
+- **BR-37 is intentionally untested.** It states that the
+  `X-Requester-Id`/selector mechanism is a temporary substitute for
+  authentication with no cryptographic identity guarantee — a constraint on
+  what the Requester context is *allowed to be*, not an observable
+  behaviour. There is nothing to assert against: every behaviour that BR-37
+  motivates (ownership checks, 404-on-cross-access, the header-validation
+  table) is already covered by API-05/06/16/17/34–37/46/48/51/56 and does
+  not depend on BR-37's wording itself.
+- **True concurrent-request races beyond API-14 are not exercised.**
+  API-14 fires two `Promise.all`-parallel requests sharing one
+  `Idempotency-Key` against the real DB unique constraint, which is
+  sufficient to prove the constraint (not just application logic) enforces
+  BR-11/BR-12, but it doesn't guarantee the same interleaving on every test
+  run; this is accepted as a property test rather than a fully deterministic
+  one.
+- **BR-38's bounded-retry exhaustion (6 consecutive collisions) is not
+  integration-tested.** Forcing 5 consecutive real unique-constraint
+  collisions on `ticketNumber` would require manipulating the DB sequence
+  counter in a way no fixture in this plan sets up; the retry-loop mechanics
+  themselves are covered at the unit level instead (UNIT-02, mocked insert).
+- **Genuine 500 (unexpected server error) paths are not forced through the
+  real API/DB stack.** Deliberately triggering an unhandled server
+  exception in an integration test (e.g. killing the DB connection
+  mid-request) is impractical to do deterministically; the 500-handling UI
+  behaviour is instead verified at the component level via a mocked
+  rejected fetch (UI-06, UI-11, UI-25).
+- **No automated pixel-diffing.** Responsive/visual correctness is verified
+  by DOM/class assertions (RESP-01–06) plus manually reviewed Playwright
+  screenshots at the fixed `ui-spec.md` §18 paths (RESP-07) — matching
+  specification.md §10's "visually verified against Playwright screenshots,
+  not personal memory," which requires screenshot evidence but not
+  automated visual-regression tooling.
+- **No dedicated "IT Priority"/"Ticket Owner" absence tests.** Both fields
+  are entirely absent from the schema, API representations, and rendered
+  field lists (specification.md §3/§11); the fixed representations and
+  column/field lists already asserted by API-04/UI-07/UI-19/UI-26 leave no
+  additional surface to test the absence of.
+
+---
+
+## 8. Resolved decisions
+
+Three gaps this plan flagged as open questions were silences in
+`api-spec.md`, not in this test plan itself — so they were fixed there
+first (and mirrored into `specification.md` §8), then closed out here with
+the new tests API-58–API-60 (§2.2).
+
+- **OQ-TEST-1**: The exact 400 response when `Idempotency-Key` is missing
+  or malformed on `POST /api/tickets`. **Decision:** 400 with
+  `{ errors: [{ "field": "Idempotency-Key", "message": "Missing or invalid
+  idempotency key" }] }`, added to the endpoint's field-validation 400
+  trigger table (api-spec.md §4, specification.md §8). **Reason:** keeps
+  `Idempotency-Key` validation inside the same body-validation shape already
+  used for every other `POST /api/tickets` field, rather than leaving it
+  undefined.
+- **OQ-TEST-2**: The response when a `DELETE .../attachments/:id` request's
+  `reason` exceeds 200 characters. **Decision:** 400 with
+  `{ errors: [{ "field": "reason", "message": "Reason must be 200 characters
+  or fewer" }] }`, added as a new response row (api-spec.md §10,
+  specification.md §8). **Reason:** BR-34's 200-character limit needs an
+  observable failure response to be enforceable, not just a documented
+  limit with no defined outcome for violating it.
+- **OQ-TEST-3**: The response when BR-38's bounded 5-attempt Ticket Number
+  retry is exhausted. **Decision:** the generic 500
+  (`{ "error": "Unexpected server error" }`), with no distinct status or
+  body, stated explicitly in api-spec.md §4. **Reason:** retry exhaustion is
+  an unexpected, not a user-correctable, failure — it belongs with every
+  other unexpected-failure path rather than inventing a new error shape for
+  one rare case. Still not integration-tested, for the reasons in §7.

--- a/docs/lab-02/ui-spec.md
+++ b/docs/lab-02/ui-spec.md
@@ -1,0 +1,746 @@
+# Lab 2 UI Specification — Zen Green Theme
+
+Sources of truth, in this order: `specification.md` and `api-spec.md`
+(both merged and authoritative — nothing below contradicts or re-decides
+anything fixed there), then the Lab 2 labsheet §7 (Zen Green Theme token
+table) and §8 (Required Application Navigation, including §8.7 Responsive
+Requirements). Where none of those fix a detail this document needs
+(typography, spacing, exact hex values, CSS class names), this document
+makes the decision — that is its job, per labsheet §17/Appendix C ("the
+final `ui-spec.md` must explicitly document the chosen color tokens,
+typography, spacing..."). Genuine ambiguities this document cannot resolve
+on its own are listed in §20 rather than invented.
+
+No code and no `tests.md` content is included here. CSS class names fixed
+in §19 are the ones `tests.md` must assert against — they are not to be
+renamed or reinvented later.
+
+---
+
+## 1. Colour tokens
+
+Fixed by labsheet §7 (verbatim values — not re-decided here):
+
+| Token | Value | Intended use |
+|---|---|---|
+| Primary green | `#006B3C` | App header background, primary actions, strong emphasis |
+| Secondary green | `#0B7A46` | Active tabs, focus accents, links, hover states |
+| Pale green | `#EAF6EF` | Selected state, success emphasis, subtle section backgrounds |
+| Page background | `#F5F7F6` | Behind all screen content |
+| Surface / cards | white, subtle border, restrained shadow | Panels, table/card surfaces, modal-like confirmation dialogs |
+| Text | dark charcoal-green, not pure black | Body text, labels, headings |
+| Editable field | white background, clear neutral border | Inputs the Requester can change |
+| Read-only field | soft gray-green or warm ivory shading | System-generated/fixed values (BR-04, AC-27) |
+| Error | dark red text and border | Field-level validation failures (BR-19, AC-04) |
+| Warning | amber callout or badge, never ordinary decoration | Genuine warnings only (e.g. BR-20 attachment-upload failure banner) |
+| Success | green confirmation, never colour-only | Ticket-created confirmation (AC-01), attachment-removed confirmation |
+
+The labsheet fixes the token *names and roles*; it does not fix literal
+hex values for Text, Editable/Read-only borders, Error, Warning, or
+Success. This document fixes those (needed for implementation and for
+`tests.md` colour assertions):
+
+| Token | Hex |
+|---|---|
+| Text (charcoal-green) | `#1C2B23` |
+| Text, muted/secondary | `#4B5A54` |
+| Editable field border | `#C9D2CE` |
+| Editable field border, focused | Secondary green `#0B7A46` |
+| Read-only field background | `#F1EFE6` (warm ivory) |
+| Read-only field border | `#DAD6C8` |
+| Error text/border | `#B3261E` |
+| Warning text | `#8A5300` |
+| Warning background | `#FCEFDC` |
+| Warning border | `#E0A458` |
+| Success text | Secondary green `#0B7A46` |
+| Success background | Pale green `#EAF6EF` |
+
+**Reservation rule**: Warning tokens (`#8A5300` / `#FCEFDC` / `#E0A458`)
+are used only where something has genuinely gone wrong but is not fatal
+(the attachment-upload-failed banner under BR-20/AC-08). They are never
+used for ordinary badges, hints, or decoration — labsheet §7 states this
+explicitly for the Warning token, and it rules out using amber for the
+Requested Priority "MEDIUM" badge (see §15).
+
+---
+
+## 2. Typography and spacing scale
+
+Not fixed by any authoritative document; fixed here.
+
+**Font family**: system font stack —
+`-apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif` (no
+external font load required).
+
+**Type scale**:
+
+| Role | Size | Weight | Used for |
+|---|---|---|---|
+| `h1` | 1.5rem (24px) | 600 | Screen titles ("Create Ticket", "My Tickets") |
+| `h2` | 1.25rem (20px) | 600 | Section headings (Attachments panel, filter group) |
+| `h3` | 1rem (16px) | 600 | Field-group headings |
+| body | 0.875rem (14px) | 400 | Field values, table cells, paragraph text |
+| label | 0.8125rem (13px) | 600 | Field labels (component rule, labsheet §8.3) |
+| small/meta | 0.75rem (12px) | 400 | Timestamps, file size, helper text |
+
+**Spacing scale** (4px base unit): `xs=4px`, `sm=8px`, `md=12px`,
+`lg=16px`, `xl=24px`, `2xl=32px`, `3xl=48px`.
+
+**Shared control geometry**: all text inputs, selects, and buttons share
+one control height of 40px (component rule, labsheet §8.3: "Inputs use
+one consistent height"); border-radius 6px on inputs and buttons, 999px
+(full pill) on badges; multiline Description uses the same 40px minimum
+but grows taller and is resizable only vertically, never causing the
+surrounding layout to reflow horizontally (labsheet §8.3).
+
+---
+
+## 3. Control states
+
+Every form control (text input, select, textarea) has exactly these
+states, styled from the tokens in §1:
+
+| State | Background | Border | Text | Notes |
+|---|---|---|---|---|
+| Editable | white | Editable field border `#C9D2CE` | Text `#1C2B23` | Default state for a control the Requester can change |
+| Read-only | Read-only field bg `#F1EFE6` | Read-only field border `#DAD6C8` | Text `#1C2B23` | Ticket Number, Ticket Date, Requester, Current Status — never editable (BR-04, BR-02, AC-27) |
+| Invalid | white (unchanged) | Error `#B3261E`, 2px | Text unchanged | Border only changes; the message (§4) carries the explanation, not colour alone |
+| Disabled | `#EEF0EF` | Editable field border, no focus ring | Text `#4B5A54` (muted) | `disabled` attribute set; cannot be focused or activated (labsheet §8.3) |
+| Focused | unchanged from Editable/Read-only | unchanged | unchanged | Adds a 2px Secondary-green (`#0B7A46`) outline, 2px offset, visible only via `:focus-visible` so mouse clicks don't show it but keyboard Tab does (AC-25) |
+
+CSS classes for these states are fixed in §19 (`field__control--readonly`,
+`field__control--invalid`, `field__control--disabled`).
+
+---
+
+## 4. Required-field marker and validation-message placement
+
+- A required field's label is followed by a red asterisk
+  (`<span class="field__required-marker">*</span>`, coloured with the
+  Error token) immediately after the label text, never inside the control
+  itself (labsheet §8.3: "the asterisk does not replace the validation
+  message").
+- Required on Create Ticket: Category, Related System, Summary,
+  Requested Priority, Description (BR-15, BR-16, BR-17, BR-18 — all
+  required per api-spec.md §4). Attachments are optional (FR-02 allows
+  "up to 5", not a minimum of 1).
+- A field's validation message renders in a `<p class="field__message
+  field__message--error">` directly below that field's control, never
+  only as a single banner at the top of the form (labsheet §8.3;
+  specification.md §6: "validation messages render beside their field,
+  never only at the top"; AC-04).
+- Message text: field name + rule violated (e.g. "Summary is required",
+  "Description must be at least 10 characters"). Exact wording is not
+  fixed by api-spec.md beyond field + rule (api-spec.md §4 worked
+  example); this document's illustrative strings are non-binding — see
+  §20 Resolved decisions (OQ-UI-1).
+- A field with a message also gets `aria-invalid="true"` and
+  `aria-describedby` pointing at the message element's `id`, so screen
+  readers announce the message when the field receives focus.
+- On any 400, already-entered field values and selected attachments are
+  preserved exactly as typed/selected (BR-19, AC-04, AC-23) — the form
+  never clears on a validation failure, whether the failure is
+  client-side or server-side.
+
+---
+
+## 5. Button hierarchy
+
+| Tier | Use | Style |
+|---|---|---|
+| Primary | The one main action per screen: Submit (Create Ticket), Continue (Requester Selection), Create Ticket (My Tickets toolbar) | Solid Primary green `#006B3C` background, white text |
+| Secondary | Supporting actions that are still affirmative: Change Requester, Add Attachment, Clear Filters, Cancel (on the Requester Selection screen) | White background, Secondary green `#0B7A46` border and text |
+| Tertiary | Low-emphasis inline actions: Preview, Download, pagination Previous/Next, sortable column headers | No border/background; Secondary green text; underline or background tint on hover/focus only |
+| Destructive | Remove (attachment soft-removal) | White background, Error `#B3261E` border and text; confirmation step required before the action fires (BR-34) |
+| Disabled | Any of the above tiers while its precondition isn't met (e.g. Continue with nothing selected, Submit mid-request is *busy*, not disabled-plain — see below) | 60% opacity, `#EEF0EF` background regardless of tier, `cursor: not-allowed`, `aria-disabled="true"`; never activates on click or Enter (labsheet §8.3) |
+| Busy | Submit while the create-ticket request is in flight (BR-13, AC-06) | Same tier styling as Primary but with a spinner icon before the label, label text changes to "Submitting…", `disabled` attribute set, `aria-busy="true"` |
+
+Every button always shows visible text; an icon may accompany the text
+but never replaces it, and any icon-only control (e.g. a small "✕" chip
+remove in the attachment picker) additionally carries an
+`aria-label` and a native `title` tooltip (labsheet §8.3).
+
+---
+
+## 6. Attachment selection and error presentation (pre-upload)
+
+This covers the client-side picker used both on Create Ticket and on
+Ticket Detail's "Add Attachment" action, before any request is sent.
+
+- A dashed-border dropzone plus a secondary "Add Files" button, either of
+  which opens the native file picker (`accept=".jpg,.jpeg,.png,.webp,.pdf"`,
+  matching BR-26).
+- Each selected file appears as a chip below the dropzone:
+  filename, size, a small file-type icon, and a "✕" remove control
+  (`aria-label="Remove {filename}"`).
+- **Client-side, pre-request checks**, each file independently:
+  - Size > 5 MB → chip renders with Error-token border/text, message
+    "File exceeds 5 MB", and is excluded from the submit payload (BR-27,
+    AC-18 — "a client-side error is shown and no upload request is
+    sent" for that file).
+  - Type not JPG/JPEG/PNG/WEBP/PDF → chip renders with Error styling,
+    message "Unsupported file type", excluded from the payload (BR-26,
+    AC-19 — client blocks first; if a request is somehow still sent
+    with a bad type, the server enforces 415, api-spec.md §7).
+  - More than 5 chips selected at once, or adding would push the
+    Ticket's active count over 5 → the newest addition is rejected
+    client-side with a banner above the dropzone: "Up to 5 attachments
+    allowed" (BR-28, BR-29, AC-16, AC-17); this is a client-side
+    convenience only — the server's 409 checks (api-spec.md §7) are
+    authoritative and still run on submit.
+- A chip that fails a client-side check is visibly distinct (Error
+  border, message beneath the chip) but stays selectable for removal —
+  it is never silently dropped without explanation.
+- Because BR-30 makes the server's validation atomic per batch, this
+  screen never partially submits — it only ever submits the files that
+  passed every client-side check, and if the server subsequently rejects
+  the whole batch (409/415/413), the failure is shown as described in
+  §7/§17, with all originally-selected chips (valid and invalid) still
+  present so the Requester can fix and retry.
+
+---
+
+## 7. Screen states: initial, loading, validation, submitting, success, failure
+
+A shared state model, reused (with the modifier classes in §19) across
+every screen that fetches or submits data:
+
+| State | Meaning | Typical rendering |
+|---|---|---|
+| Initial | First paint, nothing fetched yet or a clean unsubmitted form | Empty/default form values, or a skeleton placeholder for lists |
+| Loading | A GET is in flight | Skeleton rows (My Tickets, Ticket Detail) or a centred spinner + "Loading…" text (Requester Selection) |
+| Validation | Client-side or server-side (400) rejection of submitted input | Field-level messages per §4; form values retained (BR-19) |
+| Submitting | A mutating request (POST/DELETE) is in flight | Primary button shows Busy style (§5); form controls remain interactive except Submit itself |
+| Success | The mutation succeeded | Success-token confirmation panel/banner, non-colour-reinforced with a checkmark icon and explicit text (labsheet §7: "no reliance on color alone") |
+| Failure | The mutation or fetch failed (network error, 5xx, or an error not covered by field-level 400s) | A `.state-banner--error` panel with a safe, generic message and a Retry action where applicable; entered form values retained (AC-23) |
+
+Per-screen application:
+
+- **Requester Selection**: Loading (fetching `/api/requesters`) → Loaded
+  (dropdown populated) | Empty (zero active Requesters, labsheet §8.1) |
+  Failure (API unreachable, labsheet §8.1). No Validation/Submitting
+  state — selecting and clicking Continue only writes to
+  `sessionStorage` (BR-07), it does not call the API.
+- **Create Ticket**: Initial → (client Validation on blur/submit attempt)
+  → Submitting (BR-13, AC-06) → Success (AC-01) showing the generated
+  Ticket Number and a "View Ticket" link, or Failure. A successful Ticket
+  creation whose attachment upload failed is a distinct sub-state of
+  Success: the Ticket Number confirmation still renders, plus a
+  Warning-token banner ("Some attachments couldn't be uploaded — add them
+  from Ticket Detail") linking to Ticket Detail, per BR-20/AC-08. The
+  ordinary "Add Attachment" control on Ticket Detail is the retry
+  mechanism — no separate "Retry" button is introduced, since BR-20 only
+  requires a retry *option* to exist there, not a dedicated affordance.
+- **My Tickets**: Loading (skeleton table/cards) → Loaded, further split
+  into Empty (BR-25, AC-13) or No-results (BR-25, AC-14) or a populated
+  list, or Failure (safe error banner with Retry).
+- **Ticket Detail**: Loading → Loaded (read-only header + attachments) or
+  Failure, where a 404 (BR-36, AC-03) renders as a "not found" panel
+  indistinguishable in wording whether the Ticket doesn't exist or
+  belongs to someone else, with a "Back to My Tickets" link — never a
+  raw error dump.
+- **Attachment actions** (add/remove) on Ticket Detail: Submitting (busy
+  Add/Remove button) → Success (list updates in place) or Failure (an
+  inline Error-token message near the Attachments panel, per the 409/415/
+  413/404 cases in api-spec.md §7/§10).
+
+---
+
+## 8. Responsive layout rules
+
+Fixed by labsheet §8.7 (reproduced, not altered):
+
+| Viewport | Range | Required behavior |
+|---|---|---|
+| Desktop | ≥ 992px | Multi-column layout as specified per screen; content centred with a sensible max width |
+| Tablet | 768–991px | Two-column layout where practical; Summary and Description receive enough width |
+| Mobile | < 768px | Fields stack vertically; buttons remain touch-friendly (min 40px tap target); no horizontal page scrolling |
+| All sizes | — | No clipped labels, overlapping messages, hidden buttons, or unreadable attachment names |
+
+Applied per screen:
+
+- **Application shell**: desktop/tablet show the full horizontal nav
+  (My Tickets, Create Ticket, Requester name, Change Requester); mobile
+  collapses the nav into a hamburger toggle that opens a stacked menu
+  (labsheet §8: "responsive mobile navigation").
+- **Create Ticket**: desktop — two-column grid (system-generated fields
+  and classification fields side by side per labsheet §8.2's example
+  arrangement); tablet — two-column where practical, Summary/Description
+  each take a full-width row regardless of column count; mobile — one
+  column, every field full width, Attachments below the main fields at
+  every breakpoint (specification.md §6).
+- **My Tickets**: desktop — data table (§13); tablet — same table,
+  narrower columns, Category may abbreviate; mobile (< 768px) — table
+  is replaced entirely by stacked cards, never a horizontally-scrollable
+  table (specification.md Assumption 10; AC-24).
+- **Ticket Detail**: desktop/tablet — header fields in a responsive grid
+  (2 columns tablet, up to 4 columns desktop); mobile — header fields
+  stack one per row; the Attachments panel is always full-width below
+  the header at every breakpoint.
+
+---
+
+## 9. Accessibility
+
+- Every form control has a `<label>` associated via `for`/`id` — never a
+  placeholder used as the only label.
+- Every icon-only control (attachment chip's "✕", sortable column-header
+  sort arrows, mobile nav hamburger) has both an `aria-label` and a
+  native `title` tooltip (labsheet §8.3).
+- Keyboard focus order follows visual order on every screen; the
+  Development Requester dropdown and Continue button are reachable and
+  operable via Tab/Enter with the visible focus outline from §3 (AC-25).
+- Focus is never trapped; a confirmation step (attachment removal, §5
+  Destructive tier) is reachable and dismissible via keyboard (Esc
+  closes it, focus returns to the control that opened it).
+- Badges (§15) and states (§7) never rely on colour alone: every badge
+  pairs colour with an icon and a text label; every state banner pairs
+  colour with an icon (✓ success, ⚠ warning/failure, ℹ info) and explicit
+  text.
+- Live regions: the validation-message region and the state-banner
+  region are both `aria-live="polite"`, so a message appearing after
+  Submit is announced without moving focus away from the field.
+
+---
+
+## 10. Application shell and active navigation
+
+Structure (top to bottom): a fixed header bar containing, left to right:
+
+1. TokTickIT identity (icon + wordmark), Primary-green background,
+   white text — labsheet §7/§8.
+2. Primary nav: "My Tickets" and "Create Ticket" links.
+3. Current Requester name (read-only text) with an adjacent
+   "Change Requester" secondary-tier button.
+
+The active nav link is indicated two ways, never colour alone: a
+Secondary-green underline/bottom-border **and** `aria-current="page"`
+(non-colour indication per specification.md §6/labsheet §8's
+"clear active-page indication").
+
+"Change Requester" clears the stored selection (BR-07/BR-08) and routes
+back to the Development Requester Selection screen; no confirmation step
+is required since it discards no server data, only the client-side
+context.
+
+Below 768px, the primary nav and Requester display collapse into a
+hamburger toggle; opening it reveals the same three items stacked
+full-width.
+
+---
+
+## 11. Development Requester Selection screen
+
+Required elements (labsheet §8.1), each with its state:
+
+- TokTickIT title and the fixed explanatory text (labsheet §8.1's
+  suggested copy, used verbatim): "Select a Development Requester to test
+  requester-specific ticket behavior. This is not a login screen.
+  Authentication and role-based access will be introduced in Lab 3."
+  (BR-03, BR-37).
+- Development Requester dropdown, populated from `GET /api/requesters`
+  (only active Requesters — BR-05, AC-26).
+- Continue button (Primary tier), disabled until a Requester is selected;
+  on click, writes the selection to `sessionStorage` (BR-07) and
+  navigates to My Tickets.
+- **Loading**: spinner + "Loading Requesters…" while the request is in
+  flight.
+- **Empty**: if the active-Requesters list comes back empty, the
+  dropdown is replaced with a message ("No active Development Requesters
+  are available.") and Continue stays disabled — there is nothing to
+  select.
+- **Failure**: if the request fails, a `.state-banner--error` message
+  ("Couldn't load Development Requesters.") with a Retry button replaces
+  the dropdown area.
+- All controls keyboard-accessible (Tab to dropdown, Space/Arrow keys to
+  choose, Tab to Continue, Enter to submit) with the visible focus
+  indicator from §3 (AC-25).
+
+After selection, per specification.md §6/labsheet §8.1: the application
+shell displays the Requester's name, a Change Requester action becomes
+available, and My Tickets/Ticket Detail data is (re)fetched fresh — no
+data from a previous Requester is retained (BR-08, AC-22).
+
+---
+
+## 12. Create Ticket screen layout
+
+Field order (top to bottom), following labsheet §8.2's example
+arrangement and specification.md §6:
+
+1. **System-generated / read-only row** (Read-only field styling, §3):
+   Ticket Number ("Generated after creation" placeholder text before
+   submit), Ticket Date (today's date, display-only), Requester (the
+   selected Development Requester's name — AC-27; the client cannot
+   change this, matching BR-04).
+2. **Classification fields**, grouped together: Category (select,
+   populated from `GET /api/categories`), Related System (select,
+   populated from `GET /api/related-systems`), Requested Priority
+   (select, `LOW`/`MEDIUM`/`HIGH`, pre-selected `MEDIUM` per BR-18).
+3. **Summary** (single-line input, required, full width) and
+   **Description** (multiline textarea, required, full width, tallest
+   control on the screen) — both given the most width on the screen, per
+   specification.md §6.
+4. **Attachments** section (§6 above), below the main fields.
+5. **Actions row**: Submit (Primary, busy state per §5/BR-13) and Cancel
+   (Secondary, returns to My Tickets without saving — no confirmation
+   needed since nothing has been persisted yet).
+
+Field-by-field editable/read-only classification (ties directly to §3):
+
+| Field | Editable? | Why |
+|---|---|---|
+| Ticket Number | Read-only | System-generated on success (BR-01) |
+| Ticket Date | Read-only | `createdAt`, system-generated |
+| Requester | Read-only | Fixed to the selected Development Requester (BR-04, AC-27) |
+| Category | Editable | Requester-selected (FR-02) |
+| Related System | Editable | Requester-selected (FR-02) |
+| Requested Priority | Editable | Requester-selected, defaults `MEDIUM` (BR-18) |
+| Summary | Editable | Requester-entered (BR-15) |
+| Description | Editable | Requester-entered (BR-16) |
+| Attachments | Editable | Requester-selected (FR-02, BR-26–BR-30) |
+| Current Status | Not shown | Always `NEW` at creation (BR-02); showing a fixed constant field adds no information the Requester needs before submission — it appears on Ticket Detail instead (§16) |
+
+Neither **IT Priority** nor **Ticket Owner** appears anywhere on this
+screen, even though the labsheet's illustrative mockup (Figure 1, page 2)
+shows both — specification.md §3/§11 excludes them for Lab 2 since
+nothing in this sprint sets or owns either field.
+
+---
+
+## 13. My Tickets screen
+
+### 13.1 Toolbar
+
+Top row, left to right: search box (placeholder "Search by ticket number
+or summary…", BR-21/FR-05), Category/Requested Priority/Current Status
+filter selects (FR-06/BR-22, each defaulting to "All \_\_\_"), a page-size
+select (`.ticket-toolbar__page-size`, §19; options 10/20/50, default 10
+per BR-24 — see §20 OQ-UI-3), a Secondary-tier "Clear Filters" button,
+and a Primary-tier "Create Ticket" button that routes to Create Ticket.
+
+"Clear Filters" is present in the toolbar at all times but disabled
+(§3/§5 Disabled styling) whenever no search/filter is currently applied;
+it is additionally always present and enabled inside the No-results
+panel itself (§15), since AC-14 requires it reachable from that state
+specifically.
+
+### 13.2 Desktop columns
+
+Seven columns, each justified against a specific FR/BR (the labsheet's
+example list — Ticket Number, Summary, Category, Current Status, Last
+Updated — is explicitly "not a complete mandatory column list," §8.4):
+
+| Column | Sortable? | Justification |
+|---|---|---|
+| Ticket No. | no | Primary identifier; also the field `search` prefix-matches (BR-21) |
+| Created Date | yes (default, desc) | Default sort field (BR-23) |
+| Summary | yes | Sortable field (FR-07, BR-23); also substring-searchable (BR-21) |
+| Category | no (filterable only) | Filterable field (FR-06, BR-22) — shown so the Requester can see what a Category filter is matching |
+| Requested Priority | yes | Sortable and filterable field (FR-06, FR-07); rendered as a badge (§15) |
+| Current Status | yes | Sortable and filterable field (FR-06, FR-07); rendered as a badge (§15) |
+| Last Updated | no | Required by BR-39 ("this is the value the My Tickets 'Last Updated' column displays") |
+
+A sortable column header shows a tertiary-tier clickable label with a
+small ▲/▼ glyph indicating current direction; clicking toggles
+`sortDir` for that `sortBy` (api-spec.md §5). Only one column sorts at a
+time — clicking a different sortable header switches `sortBy` and resets
+`sortDir` to that column's default: `desc` for Created Date (BR-23),
+`asc` for Summary, `desc` for Requested Priority, and `desc` for Current
+Status — see §20 (OQ-UI-2) for the reasoning behind each.
+
+Neither **IT Priority** nor **Ticket Owner** columns appear, though both
+are visible in the labsheet's illustrative My Tickets mockup (page 11) —
+excluded per specification.md §3/§11.
+
+### 13.3 Mobile card representation (< 768px)
+
+Each Ticket renders as one card, stacked vertically (specification.md
+Assumption 10; AC-24), with no horizontally-scrollable table:
+
+- Card header row: Ticket Number (left) and the Requested Priority badge
+  (right).
+- Card title: Summary (wraps, never truncated to unreadable).
+- Secondary row: Category name and the Current Status badge.
+- Footer row: Created Date and Last Updated, each with a small-text
+  label so the two dates aren't confused.
+
+A tap anywhere on the card (except its badges) opens Ticket Detail, same
+as a desktop row click.
+
+### 13.4 Sort control on mobile
+
+Since there are no clickable column headers on a card layout, mobile
+adds a single "Sort by" select in the toolbar (values: Created Date,
+Summary, Requested Priority, Current Status, each with an asc/desc
+sub-choice) that drives the same `sortBy`/`sortDir` query parameters as
+the desktop column headers (api-spec.md §5). This is a UI-only
+convenience; it introduces no new API behavior.
+
+### 13.5 Pagination
+
+Bottom of the list: "Showing {start}–{end} of {totalCount}" text, then
+Previous / numbered page buttons / Next (tertiary tier), matching
+`page`/`totalPages` from the API response (api-spec.md §5). The current
+page button is visually distinct (Primary-green filled) and carries
+`aria-current="page"`. A page-size select (`.ticket-toolbar__page-size`,
+§19) sits in the toolbar (§13.1) alongside the filters, offering 10
+(default, BR-24), 20, and 50; changing it resets to page 1 and refetches
+— see §20 (OQ-UI-3) for why this control exists.
+
+---
+
+## 14. Priority and status badge rules
+
+Every badge is a pill (`border-radius: 999px`), and pairs colour with an
+icon glyph and a text label — never colour alone (specification.md §6:
+"distinct, non-color-only indicators"). No badge ever uses the Warning
+(amber) token as decoration, since labsheet §7 reserves that token for
+genuine warnings only (§1).
+
+### 14.1 Requested Priority (`badge--priority-*`)
+
+| Value | Icon | Background | Border | Text | Label |
+|---|---|---|---|---|---|
+| `LOW` | ↓ | Pale green `#EAF6EF` | Secondary green `#0B7A46` | Secondary green | "Low" |
+| `MEDIUM` | – | white | Secondary green `#0B7A46`, 1px | Secondary green | "Medium" |
+| `HIGH` | ↑ | white | Error `#B3261E`, 2px | Error `#B3261E` | "High" |
+
+`LOW` is filled, `MEDIUM` is outlined (thin border, white fill), `HIGH`
+is outlined with a heavier border and the Error colour — so the three
+remain distinguishable even in grayscale (icon + fill/border weight),
+satisfying the non-colour-only rule independently of the colour choice.
+`HIGH` deliberately reuses the Error token for urgency; it is never
+mistaken for a field-validation error because it only ever appears as a
+pill inside a table cell/card/detail header, never directly beneath a
+form control (§4).
+
+### 14.2 Current Status (`badge--status-*`)
+
+Lab 2's `TicketStatus` enum holds only `NEW` (specification.md §7), so
+only one status badge is defined this sprint:
+
+| Value | Icon | Background | Border | Text | Label |
+|---|---|---|---|---|---|
+| `NEW` | ● | Pale green `#EAF6EF` | Secondary green `#0B7A46` | Secondary green | "New" |
+
+The status badge uses a filled dot icon (as opposed to the priority
+badges' directional arrows/dash) so the two badge families remain
+visually distinguishable from each other, not just internally. When Lab
+3 adds further `TicketStatus` values (specification.md §7 "Schema
+evolution for Lab 3"), this table extends with new rows; nothing in this
+document depends on the enum staying single-valued.
+
+Neither table includes **IT Priority**, since that field does not exist
+in Lab 2's data model at all (specification.md §3/§11).
+
+---
+
+## 15. Empty-list versus no-results presentation (BR-25)
+
+Both render as a centred panel inside the list area (table/cards and
+pagination are hidden while either is shown), but differ in copy, icon,
+and action — never distinguished by colour alone:
+
+| | Empty (AC-13) | No-results (AC-14) |
+|---|---|---|
+| Trigger | Requester owns zero Tickets | Requester owns Tickets, but the current search/filter matches none |
+| Icon | A neutral "inbox" glyph | A neutral "search" glyph |
+| Heading | "No tickets yet" | "No tickets match your search" |
+| Body text | "Create your first ticket to get started." | "Try adjusting or clearing your filters." |
+| Action | Primary "Create Ticket" button | Secondary "Clear Filters" button (also present, enabled, in the toolbar per §13.1) |
+| Toolbar | Search/filter controls are hidden — filtering an empty set is meaningless | Search/filter controls stay visible above the panel, so the Requester can adjust them directly |
+
+---
+
+## 16. Ticket Detail read-only layout (FR-08)
+
+Two visually separated panels, top to bottom (specification.md §6:
+"read-only header fields grouped separately from the Attachments
+panel"):
+
+### 16.1 Header panel
+
+All fields read-only (§3 Read-only styling), grouped in a responsive
+grid (§8): Ticket Number, Created Date, Category, Related System,
+Requested Priority (badge, §14), Current Status (badge, §14), Summary,
+Description (full width, wraps). A "← Back to My Tickets" tertiary link
+sits above the panel.
+
+Neither **IT Priority** nor **Ticket Owner** appears, despite both being
+shown on the labsheet's illustrative Ticket Detail mockup (Figure 1) —
+excluded per specification.md §3/§11. Likewise, no Public Comments,
+Internal Notes, Actions Taken, or status-transition controls are
+present (specification.md §3 Excluded).
+
+### 16.2 Attachments panel
+
+Section heading "Attachments ({count} active)", an "Add Attachment"
+secondary button (opens the picker from §6), then the attachment list
+(§17).
+
+A failed 404 fetch of the Ticket itself (BR-36 — not found, or owned by
+someone else, worded identically) replaces both panels with the
+not-found failure state described in §7, not a partial/broken render of
+either panel.
+
+---
+
+## 17. Attachment states (active, uploading, invalid, removed, unavailable)
+
+Rendered as a list of rows inside the Attachments panel (§16.2), each row
+carrying: a file-type icon, filename, size, upload date, and
+state-specific actions/styling:
+
+| State | Trigger | Styling | Actions shown |
+|---|---|---|---|
+| Active | `isRemoved: false` | Default surface styling, full-opacity text | Preview (tertiary — opens the download URL in a new tab per BR-35), Download (tertiary), Remove (destructive, §5) |
+| Uploading | A just-selected file mid-`POST` request | Same row, with an inline progress spinner in place of the actions, muted text | none (actions disabled until the request resolves) |
+| Invalid (client-side) | A file rejected by §6's pre-upload checks | Error-token border, message beneath the row | Remove-from-selection only (it was never sent to the server) |
+| Removed | `isRemoved: true` | Muted/reduced-opacity text, no background change, a small "Removed" label with the removal date and reason (if any) shown inline | none — no Preview/Download/Remove controls, per specification.md §6 ("removed attachments show the same metadata with no action controls, visually muted") and BR-32 |
+| Unavailable | A Preview/Download click resolves to 404 (the file became removed between page load and the click, or any other fetch failure) | The row itself is unaffected; a transient inline error ("This attachment is no longer available.") appears near the clicked action and clears after a few seconds or on next successful action | Preview/Download disabled after the failure until the list is refreshed |
+
+Removing an Attachment requires the explicit confirmation step from §5's
+Destructive tier (BR-34): clicking Remove opens a small confirmation
+panel with an optional "Reason" text field (≤200 chars, live character
+count, BR-34) and Confirm/Cancel buttons; only Confirm calls
+`DELETE .../attachments/:attachmentId`.
+
+---
+
+## 18. Screenshot paths
+
+Under `artifacts/lab-02/screenshots/`, using the three subfolders fixed
+by the labsheet's required repository structure
+(`create-ticket/`, `my-tickets/`, `ticket-detail/` — no additional
+top-level folder is introduced). The Development Requester Selection
+screen's evidence is grouped under `create-ticket/`, since the labsheet's
+submission-evidence table bundles it with Create Ticket evidence (Part 6
+in labsheet §14).
+
+| Screen | State | Viewport(s) | Path |
+|---|---|---|---|
+| Requester Selection | loading | desktop | `create-ticket/requester-select-loading-desktop.png` |
+| Requester Selection | loaded (dropdown) | desktop | `create-ticket/requester-select-loaded-desktop.png` |
+| Requester Selection | empty | desktop | `create-ticket/requester-select-empty-desktop.png` |
+| Requester Selection | failure | desktop | `create-ticket/requester-select-failure-desktop.png` |
+| Create Ticket | initial | desktop, tablet, mobile | `create-ticket/create-ticket-initial-{viewport}.png` |
+| Create Ticket | validation failure | desktop | `create-ticket/create-ticket-validation-desktop.png` |
+| Create Ticket | submitting (busy) | desktop | `create-ticket/create-ticket-submitting-desktop.png` |
+| Create Ticket | success | desktop | `create-ticket/create-ticket-success-desktop.png` |
+| Create Ticket | API/network failure | desktop | `create-ticket/create-ticket-api-failure-desktop.png` |
+| Create Ticket | invalid attachment selected | desktop | `create-ticket/create-ticket-invalid-attachment-desktop.png` |
+| My Tickets | loading | desktop | `my-tickets/my-tickets-loading-desktop.png` |
+| My Tickets | populated list | desktop, tablet, mobile | `my-tickets/my-tickets-list-{viewport}.png` |
+| My Tickets | empty state | desktop | `my-tickets/my-tickets-empty-desktop.png` |
+| My Tickets | no-results state | desktop | `my-tickets/my-tickets-no-results-desktop.png` |
+| My Tickets | failure state | desktop | `my-tickets/my-tickets-failure-desktop.png` |
+| My Tickets | Requester A → B switch (before/after) | desktop | `my-tickets/my-tickets-requester-switch-before-desktop.png`, `my-tickets/my-tickets-requester-switch-after-desktop.png` |
+| Ticket Detail | loaded, active attachments | desktop, tablet, mobile | `ticket-detail/ticket-detail-loaded-{viewport}.png` |
+| Ticket Detail | removed attachment shown | desktop | `ticket-detail/ticket-detail-removed-attachment-desktop.png` |
+| Ticket Detail | remove-confirmation panel | desktop | `ticket-detail/ticket-detail-remove-confirm-desktop.png` |
+| Ticket Detail | not-found (cross-Requester/404) | desktop | `ticket-detail/ticket-detail-not-found-desktop.png` |
+
+`{viewport}` expands to `desktop`, `tablet`, or `mobile` per §8's ranges.
+
+---
+
+## 19. CSS class-naming table
+
+These are the fixed class names `tests.md` asserts against. All classes
+are plain (no CSS-Modules hashing) so Playwright/RTL selectors stay
+stable.
+
+| Group | Class | Applies to / modifier meaning |
+|---|---|---|
+| Shell | `.app-shell` | Root shell container |
+| Shell | `.app-shell__header` | Top header bar |
+| Shell | `.app-shell__nav` | Nav link group |
+| Shell | `.app-shell__nav-link` | Each nav link |
+| Shell | `.app-shell__nav-link--active` | The active-page nav link (§10) |
+| Shell | `.app-shell__requester` | Current-Requester name display |
+| Shell | `.app-shell__change-requester-btn` | Change Requester button |
+| Shell | `.app-shell__mobile-toggle` | Hamburger toggle (< 768px) |
+| Requester Selection | `.requester-select` | Screen root |
+| Requester Selection | `.requester-select__dropdown` | The dropdown control |
+| Requester Selection | `.requester-select__continue-btn` | Continue button |
+| Form field | `.field` | Field wrapper (label + control + message) |
+| Form field | `.field__label` | `<label>` element |
+| Form field | `.field__required-marker` | The red asterisk |
+| Form field | `.field__control` | The input/select/textarea itself |
+| Form field | `.field__control--readonly` | Read-only state (§3) |
+| Form field | `.field__control--invalid` | Invalid state (§3) |
+| Form field | `.field__control--disabled` | Disabled state (§3) |
+| Form field | `.field__message` | Validation message text |
+| Form field | `.field__message--error` | Error-styled message (only variant this sprint) |
+| Button | `.btn` | Base button class |
+| Button | `.btn--primary` / `.btn--secondary` / `.btn--tertiary` / `.btn--destructive` | Hierarchy tier (§5) |
+| Button | `.btn--busy` | Busy/in-flight state (§5) |
+| Button | `.btn__spinner` | Spinner element inside a busy button |
+| Attachment picker | `.attachment-picker` | Picker root (Create Ticket + Ticket Detail Add) |
+| Attachment picker | `.attachment-picker__dropzone` | Drag-drop area |
+| Attachment picker | `.attachment-picker__chip` | One selected-file chip |
+| Attachment picker | `.attachment-picker__chip--invalid` | Chip that failed a client-side check (§6) |
+| Attachment picker | `.attachment-picker__chip-remove` | The chip's "✕" control |
+| Attachment picker | `.attachment-picker__error` | Batch-level error banner (>5 files / cap reached) |
+| Attachment list | `.attachment-list` | List root (Ticket Detail Attachments panel) |
+| Attachment list | `.attachment-item` | One row |
+| Attachment list | `.attachment-item--active` / `.attachment-item--uploading` / `.attachment-item--removed` / `.attachment-item--unavailable` | Row state (§17) |
+| Attachment list | `.attachment-item__name` | Filename text |
+| Attachment list | `.attachment-item__meta` | Size/date/removal-reason text |
+| Attachment list | `.attachment-item__preview-btn` / `.attachment-item__download-btn` / `.attachment-item__remove-btn` | Row actions |
+| Attachment list | `.attachment-remove-confirm` | Removal confirmation panel (BR-34) |
+| State banner | `.state-banner` | Generic state container (§7) |
+| State banner | `.state-banner--loading` / `.state-banner--empty` / `.state-banner--no-results` / `.state-banner--error` / `.state-banner--success` / `.state-banner--warning` | State modifier |
+| Badge | `.badge` | Base badge pill |
+| Badge | `.badge--priority-low` / `.badge--priority-medium` / `.badge--priority-high` | Requested Priority (§15.1) |
+| Badge | `.badge--status-new` | Current Status (§15.2) |
+| My Tickets | `.ticket-toolbar` | Search + filters + actions row |
+| My Tickets | `.ticket-toolbar__search` | Search input |
+| My Tickets | `.ticket-toolbar__filter` | Each filter select |
+| My Tickets | `.ticket-toolbar__clear-filters-btn` | Clear Filters button |
+| My Tickets | `.ticket-toolbar__page-size` | Page-size select (10/20/50, §13.5) |
+| My Tickets | `.ticket-table` | Desktop/tablet table root |
+| My Tickets | `.ticket-table__header--sortable` | A clickable, sortable header cell |
+| My Tickets | `.ticket-table__sort-icon` | The ▲/▼ glyph |
+| My Tickets | `.ticket-card` | Mobile card root (< 768px) |
+| My Tickets | `.ticket-card__priority-badge` / `.ticket-card__status-badge` | Badge slot inside a card |
+| My Tickets | `.pagination` | Pagination root |
+| My Tickets | `.pagination__page-btn` | Each numbered page button |
+| My Tickets | `.pagination__page-btn--active` | Current page |
+| My Tickets | `.pagination__prev` / `.pagination__next` | Prev/Next controls |
+| Ticket Detail | `.ticket-detail` | Screen root |
+| Ticket Detail | `.ticket-detail__back-link` | "Back to My Tickets" link |
+| Ticket Detail | `.ticket-detail__header` | Header panel (§16.1) |
+| Ticket Detail | `.ticket-detail__attachments` | Attachments panel (§16.2) |
+
+---
+
+## 20. Resolved decisions
+
+Genuine silences in specification.md/api-spec.md that this document
+could not resolve on its own were tracked here as open questions; each
+has since been settled, with the answer and reason recorded below.
+
+- **OQ-UI-1**: The literal wording of client- and server-displayed
+  validation messages beyond "field + rule violated" — api-spec.md §4
+  fixes only that a `field` and a `message` exist per invalid field, not
+  the exact `message` string. **Decision:** unchanged; the example
+  strings used throughout this document (e.g. "Summary is required")
+  remain illustrative, not binding. **Reason:** exact message strings
+  are an implementation detail.
+- **OQ-UI-2**: The default `sortDir` for `summary`, `requestedPriority`,
+  and `status` when a Requester picks one of them as `sortBy` for the
+  first time — BR-23 fixes only the default sort (`createdAt`
+  descending) and the id-descending tiebreaker. **Decision:** ascending
+  for Summary; descending for Requested Priority; descending for Current
+  Status (§13.2). **Reason:** a Requester sorting by priority expects
+  HIGH first, and the same most-attention-first convention is applied to
+  status.
+- **OQ-UI-3**: Whether a page-size selector control is required in the
+  UI at all — BR-24 fixes the API's allowed page sizes (10/20/50) but
+  nothing in specification.md or the labsheet requires the *UI* to
+  expose changing it. **Decision:** add a page-size selector to the My
+  Tickets toolbar with options 10, 20, 50 (§13.1, §13.5). **Reason:** the
+  API supports all three, and without a UI control that capability
+  cannot be exercised or screenshotted.


### PR DESCRIPTION
Closes #12

Adds the remaining three Lab 2 specification documents plus the
review record.

- api-spec.md — endpoint-level detail for all 10 endpoints, request
  and response shapes, status codes, worked examples, and nine
  resolved decisions
- ui-spec.md — Zen Green tokens, component states, responsive rules,
  badge mapping, and a CSS class-naming contract in §19
- tests.md — 135 planned tests across six levels, full AC-01..AC-27
  traceability, test commands, and known limitations
- reviewer.md — review record

Also amends specification.md to stay consistent: category filter
renamed to categoryId, BR-23 tiebreaker made universal, two new 400
triggers.

Review focus: whether every AC maps to a test in the traceability
matrix, and whether the class names asserted in tests.md match
ui-spec.md §19 exactly.