### PR TITLE
feat(lab-02): database schema and seed

### DIFF
--- a/docs/lab-02/specification.md
+++ b/docs/lab-02/specification.md
@@ -206,7 +206,8 @@ document must follow.
   `true`), `createdAt`.
 - **RelatedSystem** — `id`, `name` (unique), `isActive` (default `true`),
   `createdAt`. Mirrors the existing `Category` shape.
-- **Category** — unchanged from Lab 1.
+- **Category** — gains `isActive` (default `true`), because BR-17 and AC-07
+  require a Category to be deactivatable.
 - **Ticket** — `id`, `ticketNumber` (unique), `requesterId` (FK →
   RequesterUser), `categoryId` (FK → Category), `relatedSystemId` (FK →
   RelatedSystem), `summary`, `description`, `requestedPriority`
@@ -245,11 +246,9 @@ document must follow.
 
 ### Migration plan
 
-- `RequesterUser` and `RelatedSystem` ship in their own migrations, tied to
-  their respective Issues.
-- **Decision**: `Ticket` and `Attachment` ship in one shared migration, since
-  they are introduced by the same Create-Ticket Issue and Attachment has a
-  hard foreign-key dependency on Ticket that has no independent meaning.
+- **Decision**: all four models ship in one migration named `lab2_schema`,
+  tied to this Issue, because the seed requires Ticket rows to exist and
+  Attachment has a hard foreign-key dependency on Ticket.
 
 ### Seed data
 

--- a/server/prisma/migrations/20260831122130_lab2_schema/migration.sql
+++ b/server/prisma/migrations/20260831122130_lab2_schema/migration.sql
@@ -1,0 +1,95 @@
+-- CreateEnum
+CREATE TYPE "Priority" AS ENUM ('LOW', 'MEDIUM', 'HIGH');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('NEW');
+
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "RequesterUser" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RequesterUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" TEXT NOT NULL,
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "summary" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "requestedPriority" "Priority" NOT NULL,
+    "status" "TicketStatus" NOT NULL DEFAULT 'NEW',
+    "idempotencyKey" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "originalFilename" TEXT NOT NULL,
+    "storedFilename" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "removedAt" TIMESTAMP(3),
+    "removalReason" TEXT,
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RequesterUser_email_key" ON "RequesterUser"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_idx" ON "Ticket"("requesterId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_createdAt_idx" ON "Ticket"("createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_requesterId_idempotencyKey_key" ON "Ticket"("requesterId", "idempotencyKey");
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_idx" ON "Attachment"("ticketId");
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -23,4 +23,75 @@ model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
   createdAt DateTime @default(now())
+  isActive  Boolean  @default(true)
+  tickets   Ticket[]
+}
+
+// ---------------------------------------------------------------------------
+// Issue 15 — Lab 2 database schema and seed
+// ---------------------------------------------------------------------------
+
+model RequesterUser {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  tickets   Ticket[]
+}
+
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  tickets   Ticket[]
+}
+
+model Ticket {
+  id                Int           @id @default(autoincrement())
+  ticketNumber      String        @unique
+  requesterId       Int
+  categoryId        Int
+  relatedSystemId   Int
+  summary           String
+  description       String
+  requestedPriority Priority
+  status            TicketStatus  @default(NEW)
+  idempotencyKey    String
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+  requester         RequesterUser @relation(fields: [requesterId], references: [id])
+  category          Category      @relation(fields: [categoryId], references: [id])
+  relatedSystem     RelatedSystem @relation(fields: [relatedSystemId], references: [id])
+  attachments       Attachment[]
+
+  @@unique([requesterId, idempotencyKey])
+  @@index([requesterId])
+  @@index([createdAt])
+}
+
+model Attachment {
+  id               Int       @id @default(autoincrement())
+  ticketId         Int
+  originalFilename String
+  storedFilename   String
+  mimeType         String
+  sizeBytes        Int
+  createdAt        DateTime  @default(now())
+  removedAt        DateTime?
+  removalReason    String?
+  ticket           Ticket    @relation(fields: [ticketId], references: [id])
+
+  @@index([ticketId])
+}
+
+enum Priority {
+  LOW
+  MEDIUM
+  HIGH
+}
+
+enum TicketStatus {
+  NEW
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -22,6 +22,10 @@ const RELATED_SYSTEM_NAMES = [
   "Printer Fleet",
 ];
 
+// Four active Requesters is the spec §7 minimum. The ~25/~5/0 ticket split
+// is defined over three of them (Alex, Sam, Priya), so Dana is the fourth
+// active Requester and holds no tickets. Priya is the one AC-13 uses for the
+// empty state; Dana exists so the selector dropdown has a fourth option.
 const REQUESTERS = [
   { name: "Alex Rivera", email: "alex.rivera@example.com", isActive: true },
   { name: "Sam Okafor", email: "sam.okafor@example.com", isActive: true },

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { getPrisma } from "../src/prisma.js";
 
 // Issue 3 — seed the four supported categories.
@@ -11,8 +12,30 @@ const CATEGORY_NAMES = [
   "Network",
 ];
 
+// Issue 15 — related systems, requesters, and tickets for Lab 2.
+const RELATED_SYSTEM_NAMES = [
+  "Email",
+  "VPN",
+  "Payroll Portal",
+  "Shared Drive",
+  "Ticketing System",
+  "Printer Fleet",
+];
+
+const REQUESTERS = [
+  { name: "Alex Rivera", email: "alex.rivera@example.com", isActive: true },
+  { name: "Sam Okafor", email: "sam.okafor@example.com", isActive: true },
+  { name: "Priya Nair", email: "priya.nair@example.com", isActive: true },
+  { name: "Dana Lim", email: "dana.lim@example.com", isActive: true },
+  { name: "Chris Boonmee", email: "chris.boonmee@example.com", isActive: false },
+];
+
+const PRIORITIES = ["LOW", "MEDIUM", "HIGH"] as const;
+
 async function main() {
   const prisma = getPrisma();
+  const year = new Date().getFullYear();
+  const base = new Date(`${year}-01-15T09:00:00Z`);
 
   // upsert() keys on the unique `name`, so re-running the seed updates the
   // existing row instead of inserting a duplicate.
@@ -25,13 +48,87 @@ async function main() {
     await prisma.category.upsert({
       where: { name },
       update: {},
-      create: { name },
+      create: { name, isActive: true },
     });
   }
 
-  const seeded = await prisma.category.findMany({ orderBy: { id: "asc" } });
-  console.log(`Seed complete — ${seeded.length} categories:`);
-  for (const c of seeded) console.log(`  ${c.id}  ${c.name}`);
+  const categories = await prisma.category.findMany({ orderBy: { id: "asc" } });
+  console.log(`Seed complete — ${categories.length} categories:`);
+  for (const c of categories) console.log(`  ${c.id}  ${c.name}`);
+
+  // Sequential for the same reason as categories: deterministic id order.
+  for (const name of RELATED_SYSTEM_NAMES) {
+    await prisma.relatedSystem.upsert({
+      where: { name },
+      update: {},
+      create: { name, isActive: true },
+    });
+  }
+
+  const relatedSystems = await prisma.relatedSystem.findMany({ orderBy: { id: "asc" } });
+  console.log(`Seed complete — ${relatedSystems.length} related systems:`);
+  for (const r of relatedSystems) console.log(`  ${r.id}  ${r.name}`);
+
+  // Sequential for the same reason as categories: deterministic id order.
+  for (const requester of REQUESTERS) {
+    await prisma.requesterUser.upsert({
+      where: { email: requester.email },
+      update: {},
+      create: requester,
+    });
+  }
+
+  const requesters = await prisma.requesterUser.findMany({ orderBy: { id: "asc" } });
+  console.log(`Seed complete — ${requesters.length} requester users:`);
+  for (const r of requesters) console.log(`  ${r.id}  ${r.name}  (active: ${r.isActive})`);
+
+  const alex = requesters.find((r) => r.name === "Alex Rivera")!;
+  const sam = requesters.find((r) => r.name === "Sam Okafor")!;
+  const priya = requesters.find((r) => r.name === "Priya Nair")!;
+
+  // 25 tickets for Alex, 5 for Sam, 0 for Priya — ticket numbers 1..30 in
+  // creation order across all requesters, per specification.md §7.
+  const ticketPlan: { requesterId: number; requesterName: string }[] = [
+    ...Array.from({ length: 25 }, () => ({ requesterId: alex.id, requesterName: alex.name })),
+    ...Array.from({ length: 5 }, () => ({ requesterId: sam.id, requesterName: sam.name })),
+  ];
+
+  const ticketCounts: Record<string, number> = { [alex.name]: 0, [sam.name]: 0, [priya.name]: 0 };
+
+  // Sequential so ticket numbers are assigned 1..30 in a deterministic order.
+  for (let i = 0; i < ticketPlan.length; i++) {
+    const seq = i + 1;
+    const ticketNumber = `TKT-${year}-${String(seq).padStart(6, "0")}`;
+    const { requesterId, requesterName } = ticketPlan[i];
+    const category = categories[i % categories.length];
+    const relatedSystem = relatedSystems[i % relatedSystems.length];
+    const requestedPriority = PRIORITIES[i % PRIORITIES.length];
+
+    await prisma.ticket.upsert({
+      where: { ticketNumber },
+      update: {},
+      create: {
+        ticketNumber,
+        requesterId,
+        categoryId: category.id,
+        relatedSystemId: relatedSystem.id,
+        summary: `Seed ticket ${seq} for ${requesterName}`,
+        description: `Auto-generated seed ticket ${seq} for ${requesterName}, used to exercise search, filter, sort, and pagination in My Tickets.`,
+        requestedPriority,
+        status: "NEW",
+        idempotencyKey: randomUUID(),
+        createdAt: new Date(base.getTime() + i * 29 * 60 * 60 * 1000),
+      },
+    });
+
+    ticketCounts[requesterName] += 1;
+  }
+
+  const totalTickets = await prisma.ticket.count();
+  console.log(`Seed complete — ${totalTickets} tickets:`);
+  for (const [name, count] of Object.entries(ticketCounts)) {
+    console.log(`  ${name}: ${count}`);
+  }
 }
 
 main()


### PR DESCRIPTION
Closes #15

## What this adds

- `RequesterUser`, `RelatedSystem`, `Ticket`, `Attachment` models
- `Priority` and `TicketStatus` enums (`TicketStatus` has `NEW` only, per §11.4)
- `Category.isActive`, required by BR-17 and AC-07
- One migration, `20260831122130_lab2_schema`
- Seed: 4 Categories, 6 Related Systems, 5 Requesters (1 inactive), 30 Tickets
  split 25 / 5 / 0 across three active Requesters

## Spec change included

`specification.md` §7 had two defects, both fixed here:

1. It said Category was unchanged from Lab 1. BR-17 and AC-07 require a
   Category to be deactivatable, so it needs `isActive`.
2. The migration plan put `Ticket` and `Attachment` in the Create Ticket
   Issue. The seed needs Ticket rows to exist, so all four models ship in
   one migration tied to this Issue.

## Two things worth a close look

1. Seed idempotency. Every loop is sequential, never `Promise.all`, because
   id order must be deterministic — BR-23 uses Ticket id descending as the
   universal sort tiebreaker. Please run `npm run prisma:seed` twice and
   confirm the printed counts are identical both times.
2. Seeded `createdAt`. The first version gave all 30 tickets the same
   timestamp, which would make the AC-11 Created Date sort pass trivially.
   Tickets are now spread 29 hours apart, set in the `create` branch only so
   re-running the seed does not move existing rows.

## Verified locally

- `npx prisma validate` — schema valid
- `npx prisma migrate status` — up to date, 2 migrations
- `npm run prisma:seed` run twice, identical output
- Tables truncated with `RESTART IDENTITY` before reseeding, so ids are 1..30
  as a fresh clone would produce
