### PR TITLE
feat(lab-02): Create Ticket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,11 @@ node_modules/
 # env & secrets
 .env
 *.env
+.env.test
 !.env.example
+
+# uploaded attachment files (Issue 18)
+server/uploads/
 # build output
 dist/
 build/

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import AppShell from "./components/AppShell.js";
 import RequesterSelect from "./screens/RequesterSelect.js";
+import CreateTicketForm from "./screens/CreateTicketForm.js";
 import { RequesterProvider, useRequester } from "./lib/requesterContext.js";
 
 // AC-02: /tickets, /tickets/new, /tickets/:id redirect here when nothing is
@@ -16,10 +17,6 @@ function RequireRequester({ children }: { children: ReactNode }) {
 
 function MyTicketsPlaceholder() {
   return <h1>My Tickets</h1>;
-}
-
-function CreateTicketPlaceholder() {
-  return <h1>Create Ticket</h1>;
 }
 
 function TicketDetailPlaceholder() {
@@ -52,7 +49,7 @@ export default function App() {
             element={
               <RequireRequester>
                 <AppShell>
-                  <CreateTicketPlaceholder />
+                  <CreateTicketForm />
                 </AppShell>
               </RequireRequester>
             }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,6 +1,11 @@
-import { API_URL } from "./lib/apiClient.js";
+import { API_URL, apiFetch } from "./lib/apiClient.js";
 
 export interface Category {
+  id: number;
+  name: string;
+}
+
+export interface RelatedSystem {
   id: number;
   name: string;
 }
@@ -8,6 +13,49 @@ export interface Category {
 export interface Requester {
   id: number;
   name: string;
+}
+
+export type Priority = "LOW" | "MEDIUM" | "HIGH";
+
+// api-spec.md §0.3 — the shared Ticket representation.
+export interface Ticket {
+  id: number;
+  ticketNumber: string;
+  requesterId: number;
+  categoryId: number;
+  relatedSystemId: number;
+  summary: string;
+  description: string;
+  requestedPriority: Priority;
+  status: "NEW";
+  createdAt: string;
+  updatedAt: string;
+}
+
+// api-spec.md §0.3 — the shared Attachment representation.
+export interface Attachment {
+  id: number;
+  ticketId: number;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: string;
+  isRemoved: boolean;
+  removedAt: string | null;
+  removalReason: string | null;
+}
+
+export interface FieldError {
+  field: string;
+  message: string;
+}
+
+export interface CreateTicketInput {
+  categoryId: number;
+  relatedSystemId: number;
+  summary: string;
+  description: string;
+  requestedPriority: Priority;
 }
 
 // Issue 17 — active Development Requesters, for the Requester Selection
@@ -25,4 +73,73 @@ export async function getRequesters(): Promise<Requester[]> {
     throw new Error(`Requesters fetch failed with status ${res.status}`);
   }
   return (await res.json()) as Requester[];
+}
+
+// Issue 18 — active Categories, for the Create Ticket category dropdown. No
+// X-Requester-Id header required (api-spec.md §0.1).
+export async function getCategories(): Promise<Category[]> {
+  const res = await fetch(`${API_URL}/api/categories`, {
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) {
+    throw new Error(`Categories fetch failed with status ${res.status}`);
+  }
+  return (await res.json()) as Category[];
+}
+
+// Issue 18 — active Related Systems, for the Create Ticket related-system
+// dropdown. No X-Requester-Id header required (api-spec.md §0.1).
+export async function getRelatedSystems(): Promise<RelatedSystem[]> {
+  const res = await fetch(`${API_URL}/api/related-systems`, {
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) {
+    throw new Error(`Related systems fetch failed with status ${res.status}`);
+  }
+  return (await res.json()) as RelatedSystem[];
+}
+
+// Issue 18 — create a Ticket (api-spec.md §4). 400 (field validation) is
+// returned to the caller as data, not thrown, so CreateTicketForm can render
+// per-field messages; any other non-2xx status throws, since it's not a
+// form-correctable failure (BR-19, AC-23).
+export type CreateTicketResult =
+  | { status: 201 | 200; ticket: Ticket }
+  | { status: 400; errors: FieldError[] };
+
+export async function createTicket(
+  input: CreateTicketInput,
+  idempotencyKey: string,
+): Promise<CreateTicketResult> {
+  const res = await apiFetch("/api/tickets", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Idempotency-Key": idempotencyKey },
+    body: JSON.stringify(input),
+  });
+
+  if (res.status === 201 || res.status === 200) {
+    return { status: res.status, ticket: (await res.json()) as Ticket };
+  }
+  if (res.status === 400) {
+    const body = (await res.json()) as { errors: FieldError[] };
+    return { status: 400, errors: body.errors };
+  }
+  throw new Error(`Create ticket failed with status ${res.status}`);
+}
+
+// Issue 18 — upload up to 5 files to an existing owned Ticket
+// (api-spec.md §7, upload only). Throws on any non-2xx status; a failed
+// upload doesn't fail the Ticket that was already created (BR-20).
+export async function uploadAttachments(ticketId: number, files: File[]): Promise<Attachment[]> {
+  const formData = new FormData();
+  for (const file of files) formData.append("files", file);
+
+  const res = await apiFetch(`/api/tickets/${ticketId}/attachments`, {
+    method: "POST",
+    body: formData,
+  });
+  if (!res.ok) {
+    throw new Error(`Attachment upload failed with status ${res.status}`);
+  }
+  return (await res.json()) as Attachment[];
 }

--- a/client/src/components/AttachmentPicker.tsx
+++ b/client/src/components/AttachmentPicker.tsx
@@ -1,0 +1,107 @@
+import { useRef, useState, type ChangeEvent, type DragEvent } from "react";
+import { getAttachmentError } from "../lib/attachmentValidation.js";
+
+interface AttachmentPickerProps {
+  files: File[];
+  onChange: (files: File[]) => void;
+}
+
+const MAX_ATTACHMENTS = 5;
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ui-spec.md §6, §19 — the pre-upload picker used on Create Ticket (and,
+// later, Ticket Detail's Add Attachment). Client-side checks are a
+// convenience only; the server's checks (api-spec.md §7) are authoritative.
+export default function AttachmentPicker({ files, onChange }: AttachmentPickerProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [batchError, setBatchError] = useState<string | undefined>();
+
+  function addFiles(newFiles: File[]) {
+    if (newFiles.length === 0) return;
+    // BR-28/BR-29: more than 5 selected at once, or adding would push the
+    // total over 5 — the newest addition is rejected wholesale.
+    if (files.length + newFiles.length > MAX_ATTACHMENTS) {
+      setBatchError("Up to 5 attachments allowed");
+      return;
+    }
+    setBatchError(undefined);
+    onChange([...files, ...newFiles]);
+  }
+
+  function handleInputChange(e: ChangeEvent<HTMLInputElement>) {
+    addFiles(Array.from(e.target.files ?? []));
+    e.target.value = "";
+  }
+
+  function handleDrop(e: DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    addFiles(Array.from(e.dataTransfer.files));
+  }
+
+  function handleRemove(index: number) {
+    setBatchError(undefined);
+    onChange(files.filter((_, i) => i !== index));
+  }
+
+  return (
+    <div className="attachment-picker">
+      <div
+        className="attachment-picker__dropzone"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleDrop}
+      >
+        <p>Drag files here, or</p>
+        <button
+          type="button"
+          className="btn btn--secondary"
+          onClick={() => inputRef.current?.click()}
+        >
+          Add Files
+        </button>
+        <input
+          ref={inputRef}
+          type="file"
+          aria-label="Attachments"
+          accept=".jpg,.jpeg,.png,.webp,.pdf"
+          multiple
+          hidden
+          onChange={handleInputChange}
+        />
+      </div>
+
+      {batchError && <p className="attachment-picker__error">{batchError}</p>}
+
+      {files.length > 0 && (
+        <ul>
+          {files.map((file, index) => {
+            const error = getAttachmentError(file);
+            return (
+              <li
+                key={`${file.name}-${file.lastModified}-${index}`}
+                className={`attachment-picker__chip${error ? " attachment-picker__chip--invalid" : ""}`}
+              >
+                <span className="attachment-picker__chip-name">{file.name}</span>
+                <span className="attachment-picker__chip-size">{formatSize(file.size)}</span>
+                {error && <span className="attachment-picker__chip-message">{error}</span>}
+                <button
+                  type="button"
+                  className="attachment-picker__chip-remove"
+                  aria-label={`Remove ${file.name}`}
+                  title={`Remove ${file.name}`}
+                  onClick={() => handleRemove(index)}
+                >
+                  ✕
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/Field.tsx
+++ b/client/src/components/Field.tsx
@@ -1,0 +1,60 @@
+import { cloneElement, isValidElement, type ReactElement, type ReactNode } from "react";
+
+interface FieldProps {
+  label: string;
+  htmlFor: string;
+  required?: boolean;
+  error?: string;
+  readOnly?: boolean;
+  children: ReactNode;
+}
+
+// ui-spec.md §3, §4, §19 — shared field wrapper: label + required marker +
+// the control (cloned so it gets the shared field__control styling and its
+// id/aria wiring) + an error message beneath the control, never only at the
+// top of the form.
+export default function Field({
+  label,
+  htmlFor,
+  required = false,
+  error,
+  readOnly = false,
+  children,
+}: FieldProps) {
+  const messageId = `${htmlFor}-message`;
+  const hasError = Boolean(error);
+
+  const controlClassName = [
+    "field__control",
+    readOnly ? "field__control--readonly" : "",
+    hasError ? "field__control--invalid" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const control = isValidElement(children)
+    ? cloneElement(children as ReactElement<{ className?: string }>, {
+        id: htmlFor,
+        className: [controlClassName, (children as ReactElement<{ className?: string }>).props.className]
+          .filter(Boolean)
+          .join(" "),
+        "aria-invalid": hasError ? "true" : undefined,
+        "aria-describedby": hasError ? messageId : undefined,
+      } as Partial<{ className?: string }> & Record<string, unknown>)
+    : children;
+
+  return (
+    <div className="field">
+      <label className="field__label" htmlFor={htmlFor}>
+        {label}
+        {required && <span className="field__required-marker">*</span>}
+      </label>
+      {control}
+      {hasError && (
+        <p id={messageId} className="field__message field__message--error" aria-live="polite">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/client/src/lib/attachmentValidation.ts
+++ b/client/src/lib/attachmentValidation.ts
@@ -1,0 +1,23 @@
+// ui-spec.md §6 / BR-26, BR-27 — client-side, pre-request attachment checks.
+// Shared between AttachmentPicker (chip display) and CreateTicketForm
+// (deciding what actually gets submitted).
+
+export const MAX_ATTACHMENT_SIZE_BYTES = 5 * 1024 * 1024;
+const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".pdf"];
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "application/pdf"];
+
+function hasAllowedExtension(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return ALLOWED_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+// Returns the message for the first check the file fails, or undefined if
+// it passes both. A blank browser-reported type (some OSes omit it) is
+// treated as "unknown, judge by extension only" rather than an automatic
+// failure.
+export function getAttachmentError(file: File): string | undefined {
+  const typeOk = hasAllowedExtension(file.name) && (file.type === "" || ALLOWED_MIME_TYPES.includes(file.type));
+  if (!typeOk) return "Unsupported file type";
+  if (file.size > MAX_ATTACHMENT_SIZE_BYTES) return "File exceeds 5 MB";
+  return undefined;
+}

--- a/client/src/screens/CreateTicketForm.tsx
+++ b/client/src/screens/CreateTicketForm.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import {
+  createTicket,
+  getCategories,
+  getRelatedSystems,
+  uploadAttachments,
+  type Category,
+  type Priority,
+  type RelatedSystem,
+  type Ticket,
+} from "../api.js";
+import { useRequester } from "../lib/requesterContext.js";
+import { getAttachmentError } from "../lib/attachmentValidation.js";
+import Field from "../components/Field.js";
+import AttachmentPicker from "../components/AttachmentPicker.js";
+import StateBanner from "../components/StateBanner.js";
+
+type ScreenState = "form" | "submitting" | "error";
+
+function validate(
+  categoryId: string,
+  relatedSystemId: string,
+  summary: string,
+  description: string,
+): Record<string, string> {
+  const errors: Record<string, string> = {};
+
+  if (!categoryId) errors.categoryId = "Category is required";
+  if (!relatedSystemId) errors.relatedSystemId = "Related System is required";
+
+  const trimmedSummary = summary.trim();
+  if (trimmedSummary.length === 0) {
+    errors.summary = "Summary is required";
+  } else if (trimmedSummary.length < 5 || trimmedSummary.length > 120) {
+    errors.summary = "Summary must be between 5 and 120 characters";
+  }
+
+  const trimmedDescription = description.trim();
+  if (trimmedDescription.length === 0) {
+    errors.description = "Description is required";
+  } else if (trimmedDescription.length < 10 || trimmedDescription.length > 2000) {
+    errors.description = "Description must be between 10 and 2000 characters";
+  }
+
+  return errors;
+}
+
+export default function CreateTicketForm() {
+  const { requester } = useRequester();
+  const navigate = useNavigate();
+
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [relatedSystems, setRelatedSystems] = useState<RelatedSystem[]>([]);
+
+  const [categoryId, setCategoryId] = useState("");
+  const [relatedSystemId, setRelatedSystemId] = useState("");
+  const [priority, setPriority] = useState<Priority>("MEDIUM");
+  const [summary, setSummary] = useState("");
+  const [description, setDescription] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
+
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [screenState, setScreenState] = useState<ScreenState>("form");
+  const [createdTicket, setCreatedTicket] = useState<Ticket | null>(null);
+  const [attachmentWarning, setAttachmentWarning] = useState(false);
+
+  // BR-11/BR-13, ui-spec.md §12: a fresh key per mount, and again after a
+  // successful submit so creating another Ticket without navigating away
+  // doesn't replay the previous one.
+  const [idempotencyKey, setIdempotencyKey] = useState(() => crypto.randomUUID());
+
+  // BR-13: React state alone can't block a click that lands before the next
+  // render; this ref makes the guard synchronous.
+  const submittingRef = useRef(false);
+
+  useEffect(() => {
+    getCategories()
+      .then(setCategories)
+      .catch(() => {});
+    getRelatedSystems()
+      .then(setRelatedSystems)
+      .catch(() => {});
+  }, []);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (submittingRef.current) return;
+
+    const errors = validate(categoryId, relatedSystemId, summary, description);
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    submittingRef.current = true;
+    setFieldErrors({});
+    setScreenState("submitting");
+
+    try {
+      const result = await createTicket(
+        {
+          categoryId: Number(categoryId),
+          relatedSystemId: Number(relatedSystemId),
+          summary,
+          description,
+          requestedPriority: priority,
+        },
+        idempotencyKey,
+      );
+
+      if (result.status === 400) {
+        const errs: Record<string, string> = {};
+        for (const fieldError of result.errors) errs[fieldError.field] = fieldError.message;
+        setFieldErrors(errs);
+        setScreenState("form");
+        submittingRef.current = false;
+        return;
+      }
+
+      const ticket = result.ticket;
+      setCreatedTicket(ticket);
+
+      const validFiles = files.filter((file) => !getAttachmentError(file));
+      if (validFiles.length > 0) {
+        try {
+          await uploadAttachments(ticket.id, validFiles);
+          setAttachmentWarning(false);
+        } catch {
+          setAttachmentWarning(true);
+        }
+      } else {
+        setAttachmentWarning(false);
+      }
+
+      setSummary("");
+      setDescription("");
+      setFiles([]);
+      setIdempotencyKey(crypto.randomUUID());
+      setScreenState("form");
+      submittingRef.current = false;
+    } catch {
+      setScreenState("error");
+      submittingRef.current = false;
+    }
+  }
+
+  const ticketNumberDisplay = createdTicket ? createdTicket.ticketNumber : "Generated after creation";
+  const ticketDateDisplay = createdTicket
+    ? new Date(createdTicket.createdAt).toLocaleDateString()
+    : new Date().toLocaleDateString();
+
+  return (
+    <div className="create-ticket">
+      <h1>Create Ticket</h1>
+
+      {createdTicket && (
+        <StateBanner variant="success">
+          <p>
+            Ticket {createdTicket.ticketNumber} created.{" "}
+            <Link to={`/tickets/${createdTicket.id}`}>View Ticket</Link>
+          </p>
+        </StateBanner>
+      )}
+
+      {createdTicket && attachmentWarning && (
+        <StateBanner variant="warning">
+          <p>
+            Some attachments couldn't be uploaded — add them from{" "}
+            <Link to={`/tickets/${createdTicket.id}`}>Ticket Detail</Link>.
+          </p>
+        </StateBanner>
+      )}
+
+      {screenState === "error" && (
+        <StateBanner variant="error">
+          <p>Couldn't create the Ticket. Please try again.</p>
+        </StateBanner>
+      )}
+
+      <form onSubmit={handleSubmit} noValidate>
+        <div className="create-ticket__readonly-row">
+          <Field label="Ticket Number" htmlFor="ticket-number" readOnly>
+            <input type="text" value={ticketNumberDisplay} readOnly />
+          </Field>
+          <Field label="Ticket Date" htmlFor="ticket-date" readOnly>
+            <input type="text" value={ticketDateDisplay} readOnly />
+          </Field>
+          <Field label="Requester" htmlFor="ticket-requester" readOnly>
+            <input type="text" value={requester?.name ?? ""} readOnly />
+          </Field>
+        </div>
+
+        <div className="create-ticket__classification-row">
+          <Field
+            label="Category"
+            htmlFor="ticket-category"
+            required
+            error={fieldErrors.categoryId}
+          >
+            <select value={categoryId} onChange={(e) => setCategoryId(e.target.value)}>
+              <option value="">Select a Category…</option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <Field
+            label="Related System"
+            htmlFor="ticket-related-system"
+            required
+            error={fieldErrors.relatedSystemId}
+          >
+            <select value={relatedSystemId} onChange={(e) => setRelatedSystemId(e.target.value)}>
+              <option value="">Select a Related System…</option>
+              {relatedSystems.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Requested Priority" htmlFor="ticket-priority" required>
+            <select
+              value={priority}
+              onChange={(e) => setPriority(e.target.value as Priority)}
+            >
+              <option value="LOW">Low</option>
+              <option value="MEDIUM">Medium</option>
+              <option value="HIGH">High</option>
+            </select>
+          </Field>
+        </div>
+
+        <Field label="Summary" htmlFor="ticket-summary" required error={fieldErrors.summary}>
+          <input type="text" value={summary} onChange={(e) => setSummary(e.target.value)} />
+        </Field>
+
+        <Field
+          label="Description"
+          htmlFor="ticket-description"
+          required
+          error={fieldErrors.description}
+        >
+          <textarea value={description} onChange={(e) => setDescription(e.target.value)} />
+        </Field>
+
+        <AttachmentPicker files={files} onChange={setFiles} />
+
+        <div className="create-ticket__actions">
+          <button
+            type="submit"
+            className={`btn btn--primary${screenState === "submitting" ? " btn--busy" : ""}`}
+            disabled={screenState === "submitting"}
+            aria-busy={screenState === "submitting"}
+          >
+            {screenState === "submitting" && <span className="btn__spinner" aria-hidden="true" />}
+            {screenState === "submitting" ? "Submitting…" : "Submit"}
+          </button>
+          <button type="button" className="btn btn--secondary" onClick={() => navigate("/tickets")}>
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/client/src/styles/components.css
+++ b/client/src/styles/components.css
@@ -311,3 +311,163 @@
 .requester-select__continue-btn {
   align-self: flex-start;
 }
+
+/* ---------------------------------------------------------------------- */
+/* Form field — ui-spec.md §3, §4, §19                                    */
+/* ---------------------------------------------------------------------- */
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.field__label {
+  font-size: var(--font-size-label);
+  font-weight: var(--font-weight-label);
+  color: var(--color-text);
+}
+
+.field__required-marker {
+  color: var(--color-error);
+  margin-left: var(--space-xs);
+}
+
+.field__control {
+  height: var(--control-height);
+  padding: 0 var(--space-md);
+  border-radius: var(--radius-control);
+  border: 1px solid var(--color-field-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-body);
+}
+
+textarea.field__control {
+  height: auto;
+  min-height: 96px;
+  padding-top: var(--space-sm);
+  padding-bottom: var(--space-sm);
+  resize: vertical;
+}
+
+.field__control--readonly {
+  background: var(--color-readonly-bg);
+  border-color: var(--color-readonly-border);
+}
+
+.field__control--invalid {
+  border-color: var(--color-error);
+  border-width: 2px;
+}
+
+.field__control--disabled,
+.field__control:disabled {
+  background: var(--color-disabled-bg);
+  color: var(--color-text-muted);
+  cursor: not-allowed;
+}
+
+.field__message {
+  font-size: var(--font-size-small);
+  margin: 0;
+}
+
+.field__message--error {
+  color: var(--color-error);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Attachment picker — ui-spec.md §6, §19                                 */
+/* ---------------------------------------------------------------------- */
+
+.attachment-picker {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.attachment-picker__dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-xl);
+  border: 2px dashed var(--color-field-border);
+  border-radius: var(--radius-control);
+  background: var(--color-surface);
+  text-align: center;
+}
+
+.attachment-picker__error {
+  color: var(--color-error);
+  font-size: var(--font-size-small);
+  margin: 0;
+}
+
+.attachment-picker__chip {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--color-field-border);
+  border-radius: var(--radius-control);
+  background: var(--color-surface);
+  font-size: var(--font-size-small);
+  list-style: none;
+}
+
+.attachment-picker__chip--invalid {
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+
+.attachment-picker__chip-remove {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: var(--font-size-body);
+  line-height: 1;
+  margin-left: auto;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Create Ticket — ui-spec.md §12, §8                                     */
+/* ---------------------------------------------------------------------- */
+
+.create-ticket {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.create-ticket__readonly-row,
+.create-ticket__classification-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-lg);
+}
+
+.create-ticket__actions {
+  display: flex;
+  gap: var(--space-md);
+}
+
+@media (max-width: 991px) {
+  .create-ticket__readonly-row,
+  .create-ticket__classification-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 767px) {
+  .create-ticket__readonly-row,
+  .create-ticket__classification-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/client/tests/lab-02/AttachmentPicker.test.tsx
+++ b/client/tests/lab-02/AttachmentPicker.test.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AttachmentPicker from "../../src/components/AttachmentPicker.js";
+
+function Wrapper() {
+  const [files, setFiles] = useState<File[]>([]);
+  return <AttachmentPicker files={files} onChange={setFiles} />;
+}
+
+function makeFile(name: string, sizeBytes: number, type: string): File {
+  return new File([new Uint8Array(sizeBytes)], name, { type });
+}
+
+describe("AttachmentPicker", () => {
+  // UI-14
+  it("flags a file over 5 MB as an invalid chip, excluded from submission", async () => {
+    const user = userEvent.setup();
+    render(<Wrapper />);
+    const bigFile = makeFile("photo.png", 6 * 1024 * 1024, "image/png");
+
+    await user.upload(screen.getByLabelText("Attachments"), bigFile);
+
+    const chip = screen.getByText("photo.png").closest(".attachment-picker__chip");
+    expect(chip).toHaveClass("attachment-picker__chip--invalid");
+    expect(screen.getByText("File exceeds 5 MB")).toBeInTheDocument();
+  });
+
+  // UI-15
+  it("flags an unsupported file type as an invalid chip, excluded from submission", async () => {
+    // applyAccept: false — a real user (or a renamed file) can still submit
+    // a file the input's `accept` attribute would normally filter out; the
+    // component's own check must catch it regardless.
+    const user = userEvent.setup({ applyAccept: false });
+    render(<Wrapper />);
+    const badFile = makeFile("script.exe", 1024, "application/x-msdownload");
+
+    await user.upload(screen.getByLabelText("Attachments"), badFile);
+
+    const chip = screen.getByText("script.exe").closest(".attachment-picker__chip");
+    expect(chip).toHaveClass("attachment-picker__chip--invalid");
+    expect(screen.getByText("Unsupported file type")).toBeInTheDocument();
+  });
+
+  // UI-16
+  it("rejects a 6th file with a batch-level banner when 5 are already selected", async () => {
+    const user = userEvent.setup();
+    render(<Wrapper />);
+    const input = screen.getByLabelText("Attachments");
+
+    for (let i = 0; i < 5; i++) {
+      await user.upload(input, makeFile(`file-${i}.png`, 1024, "image/png"));
+    }
+    expect(screen.getAllByRole("listitem")).toHaveLength(5);
+
+    await user.upload(input, makeFile("file-6.png", 1024, "image/png"));
+
+    expect(screen.getByText("Up to 5 attachments allowed")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(5);
+    expect(screen.queryByText("file-6.png")).not.toBeInTheDocument();
+  });
+
+  // UI-17
+  it("removes a file from the selection when its ✕ control is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Wrapper />);
+    await user.upload(
+      screen.getByLabelText("Attachments"),
+      makeFile("note.pdf", 1024, "application/pdf"),
+    );
+
+    expect(screen.getByText("note.pdf")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Remove note.pdf" }));
+
+    expect(screen.queryByText("note.pdf")).not.toBeInTheDocument();
+  });
+});

--- a/client/tests/lab-02/CreateTicketForm.test.tsx
+++ b/client/tests/lab-02/CreateTicketForm.test.tsx
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import CreateTicketForm from "../../src/screens/CreateTicketForm.js";
+import { RequesterProvider, setSelectedRequester } from "../../src/lib/requesterContext.js";
+
+const defaultTicket = {
+  id: 42,
+  ticketNumber: "TKT-2026-000042",
+  requesterId: 1,
+  categoryId: 1,
+  relatedSystemId: 1,
+  summary: "Laptop won't power on",
+  description: "Screen stays black after the firmware update finished overnight.",
+  requestedPriority: "MEDIUM",
+  status: "NEW",
+  createdAt: "2026-08-29T10:15:00.000Z",
+  updatedAt: "2026-08-29T10:15:00.000Z",
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as Response;
+}
+
+type ResponseSource = Response | (() => Response | Promise<Response>);
+
+function resolveSource(source: ResponseSource | undefined, fallback: Response) {
+  if (!source) return fallback;
+  return typeof source === "function" ? source() : source;
+}
+
+function setupFetch(options: {
+  categories?: unknown[];
+  relatedSystems?: unknown[];
+  createTicketResponse?: ResponseSource;
+  uploadResponse?: ResponseSource;
+} = {}) {
+  const {
+    categories = [{ id: 1, name: "Hardware" }],
+    relatedSystems = [{ id: 1, name: "Email" }],
+    createTicketResponse,
+    uploadResponse,
+  } = options;
+
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+
+    if (url.includes("/api/categories")) return jsonResponse(categories);
+    if (url.includes("/api/related-systems")) return jsonResponse(relatedSystems);
+    if (url.includes("/attachments")) {
+      return resolveSource(uploadResponse, jsonResponse([], 201));
+    }
+    if (url.endsWith("/api/tickets") && method === "POST") {
+      return resolveSource(createTicketResponse, jsonResponse(defaultTicket, 201));
+    }
+    throw new Error(`Unexpected fetch: ${method} ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function renderScreen() {
+  setSelectedRequester({ id: 1, name: "Alex Rivera" });
+  return render(
+    <RequesterProvider>
+      <MemoryRouter initialEntries={["/tickets/new"]}>
+        <Routes>
+          <Route path="/tickets/new" element={<CreateTicketForm />} />
+          <Route path="/tickets/:id" element={<h1>Ticket Detail</h1>} />
+          <Route path="/tickets" element={<h1>My Tickets</h1>} />
+        </Routes>
+      </MemoryRouter>
+    </RequesterProvider>,
+  );
+}
+
+async function fillValidForm() {
+  await screen.findByLabelText(/^Category/);
+  await userEvent.selectOptions(screen.getByLabelText(/^Category/), "1");
+  await userEvent.selectOptions(screen.getByLabelText(/^Related System/), "1");
+  await userEvent.type(screen.getByLabelText(/^Summary/), "Laptop won't power on");
+  await userEvent.type(
+    screen.getByLabelText(/^Description/),
+    "Screen stays black after the firmware update finished overnight.",
+  );
+}
+
+describe("CreateTicketForm", () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  // UI-07
+  it("renders read-only Ticket Number placeholder, today's date, and the Requester name", async () => {
+    setupFetch();
+    renderScreen();
+
+    const ticketNumberField = await screen.findByLabelText("Ticket Number");
+    expect(ticketNumberField).toHaveValue("Generated after creation");
+    expect(ticketNumberField).toHaveClass("field__control--readonly");
+
+    expect(screen.getByLabelText("Requester")).toHaveValue("Alex Rivera");
+    expect(screen.getByLabelText("Requester")).toHaveClass("field__control--readonly");
+
+    const todayText = new Date().toLocaleDateString();
+    expect(screen.getByLabelText("Ticket Date")).toHaveValue(todayText);
+  });
+
+  // UI-08
+  it("shows an inline message for an empty Summary and sends no API request", async () => {
+    const fetchMock = setupFetch();
+    renderScreen();
+
+    await screen.findByLabelText(/^Category/);
+    await userEvent.selectOptions(screen.getByLabelText(/^Category/), "1");
+    await userEvent.selectOptions(screen.getByLabelText(/^Related System/), "1");
+    await userEvent.type(
+      screen.getByLabelText(/^Description/),
+      "Screen stays black after the firmware update finished overnight.",
+    );
+    // Summary intentionally left empty.
+    await userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(await screen.findByText("Summary is required")).toBeInTheDocument();
+
+    const postCalls = fetchMock.mock.calls.filter(([, init]) => (init as RequestInit)?.method === "POST");
+    expect(postCalls).toHaveLength(0);
+  });
+
+  // UI-09
+  it("preserves entered values and attachment chips after a 400 response", async () => {
+    setupFetch({
+      createTicketResponse: () =>
+        jsonResponse({ errors: [{ field: "summary", message: "Summary must be at least 5 characters" }] }, 400),
+    });
+    renderScreen();
+
+    await fillValidForm();
+    const file = new File(["hello"], "note.png", { type: "image/png" });
+    await userEvent.upload(screen.getByLabelText("Attachments"), file);
+
+    await userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(await screen.findByText("Summary must be at least 5 characters")).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Summary/)).toHaveValue("Laptop won't power on");
+    expect(screen.getByText("note.png")).toBeInTheDocument();
+  });
+
+  // UI-10
+  it("shows busy state after the first click and ignores a rapid second click", async () => {
+    let resolveCreate!: (res: Response) => void;
+    const pending = new Promise<Response>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const fetchMock = setupFetch({ createTicketResponse: () => pending });
+    renderScreen();
+
+    await fillValidForm();
+    const submitBtn = screen.getByRole("button", { name: "Submit" });
+
+    await userEvent.click(submitBtn);
+    await userEvent.click(submitBtn);
+
+    const busyBtn = await screen.findByRole("button", { name: "Submitting…" });
+    expect(busyBtn).toHaveClass("btn--busy");
+    expect(busyBtn).toBeDisabled();
+
+    const postCallsBeforeResolve = fetchMock.mock.calls.filter(
+      ([url, init]) => String(url).endsWith("/api/tickets") && (init as RequestInit)?.method === "POST",
+    );
+    expect(postCallsBeforeResolve).toHaveLength(1);
+
+    resolveCreate(jsonResponse(defaultTicket, 201));
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Submitting…" })).not.toBeInTheDocument(),
+    );
+  });
+
+  // UI-11
+  it("shows a failure banner and preserves entered values on a network/API failure", async () => {
+    setupFetch({
+      createTicketResponse: () => {
+        throw new Error("network down");
+      },
+    });
+    renderScreen();
+
+    await fillValidForm();
+    await userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(
+      await screen.findByText("Couldn't create the Ticket. Please try again."),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Summary/)).toHaveValue("Laptop won't power on");
+  });
+
+  // UI-12
+  it("renders the Ticket Number and a View Ticket link on success", async () => {
+    setupFetch();
+    renderScreen();
+
+    await fillValidForm();
+    await userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(await screen.findByText(/TKT-2026-000042 created/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View Ticket" })).toHaveAttribute(
+      "href",
+      "/tickets/42",
+    );
+  });
+
+  // UI-13
+  it("shows success plus a Warning-token banner when the attachment upload fails", async () => {
+    setupFetch({
+      uploadResponse: () => jsonResponse({ error: "Unexpected server error" }, 500),
+    });
+    renderScreen();
+
+    await fillValidForm();
+    const file = new File(["hello"], "note.png", { type: "image/png" });
+    await userEvent.upload(screen.getByLabelText("Attachments"), file);
+
+    await userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(await screen.findByText(/TKT-2026-000042 created/)).toBeInTheDocument();
+    const warning = await screen.findByText(/Some attachments couldn't be uploaded/);
+    expect(warning.closest(".state-banner--warning")).not.toBeNull();
+    expect(screen.getByRole("link", { name: "Ticket Detail" })).toHaveAttribute(
+      "href",
+      "/tickets/42",
+    );
+  });
+});

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "multer": "^2.3.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/multer": "^1.4.12",
         "@types/node": "^22.10.2",
         "@types/supertest": "^6.0.2",
         "prisma": "^5.22.0",
@@ -1023,6 +1025,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
+      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -1230,6 +1242,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1282,6 +1300,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1380,6 +1415,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -2035,6 +2085,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -2245,6 +2314,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/rollup": {
@@ -2482,6 +2565,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -2651,6 +2751,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2680,6 +2786,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -15,11 +15,13 @@
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "multer": "^2.3.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/multer": "^1.4.12",
     "@types/node": "^22.10.2",
     "@types/supertest": "^6.0.2",
     "prisma": "^5.22.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,12 @@
-import express, { Request, Response } from "express";
+import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
+import multer from "multer";
+import path from "node:path";
+import { Prisma, type Ticket, type Attachment } from "@prisma/client";
 import { getPrisma } from "./prisma.js";
+import { generateTicketNumber } from "./ticketNumber.js";
+import { validateTicketInput } from "./ticketValidation.js";
+import { storeUploadedFile } from "./uploads.js";
 // getPrisma() is your lazy database handle. Call it INSIDE a route when you
 // need the DB.
 
@@ -28,6 +34,7 @@ app.get("/api/health", (_req: Request, res: Response) => {
 app.get("/api/categories", async (_req: Request, res: Response) => {
   try {
     const categories = await getPrisma().category.findMany({
+      where: { isActive: true },
       orderBy: { id: "asc" },
       select: { id: true, name: true },
     });
@@ -59,5 +66,337 @@ app.get("/api/requesters", async (_req: Request, res: Response) => {
     res.status(500).json({ error: "Unexpected server error" });
   }
 });
+
+// ---------------------------------------------------------------------------
+// Issue 18 — Create Ticket
+// Shared helpers used by every Ticket/Attachment endpoint below.
+// ---------------------------------------------------------------------------
+
+// api-spec.md §0.1 — the same X-Requester-Id check for every Ticket/
+// Attachment endpoint: 400 if missing/non-integer, 403 if not an active
+// RequesterUser, otherwise proceeds scoped to that Requester.
+type RequesterCheck =
+  | { ok: true; requesterId: number }
+  | {
+      ok: false;
+      status: 400 | 403;
+      body: { errors: { field: string; message: string }[] } | { error: string };
+    };
+
+async function checkRequester(req: Request): Promise<RequesterCheck> {
+  const raw = req.header("X-Requester-Id");
+  const requesterId = raw !== undefined && /^\d+$/.test(raw.trim()) ? Number(raw.trim()) : NaN;
+  if (!Number.isInteger(requesterId)) {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        errors: [{ field: "X-Requester-Id", message: "Missing or invalid requester header" }],
+      },
+    };
+  }
+  const requester = await getPrisma().requesterUser.findUnique({ where: { id: requesterId } });
+  if (!requester || !requester.isActive) {
+    return { ok: false, status: 403, body: { error: "Selected Requester is not active" } };
+  }
+  return { ok: true, requesterId };
+}
+
+// api-spec.md §0.3 — the shared Ticket representation (no idempotencyKey,
+// no attachments field on this endpoint's shape).
+function ticketToJSON(t: Ticket) {
+  return {
+    id: t.id,
+    ticketNumber: t.ticketNumber,
+    requesterId: t.requesterId,
+    categoryId: t.categoryId,
+    relatedSystemId: t.relatedSystemId,
+    summary: t.summary,
+    description: t.description,
+    requestedPriority: t.requestedPriority,
+    status: t.status,
+    createdAt: t.createdAt.toISOString(),
+    updatedAt: t.updatedAt.toISOString(),
+  };
+}
+
+// api-spec.md §0.3 — the shared Attachment representation (no
+// storedFilename; isRemoved is derived from removedAt, not a stored column).
+function attachmentToJSON(a: Attachment) {
+  return {
+    id: a.id,
+    ticketId: a.ticketId,
+    originalFilename: a.originalFilename,
+    mimeType: a.mimeType,
+    sizeBytes: a.sizeBytes,
+    createdAt: a.createdAt.toISOString(),
+    isRemoved: a.removedAt !== null,
+    removedAt: a.removedAt ? a.removedAt.toISOString() : null,
+    removalReason: a.removalReason,
+  };
+}
+
+function isUniqueConstraintViolation(err: unknown, ...fields: string[]): boolean {
+  if (!(err instanceof Prisma.PrismaClientKnownRequestError) || err.code !== "P2002") return false;
+  const target = err.meta?.target;
+  const targetFields = Array.isArray(target) ? target : typeof target === "string" ? [target] : [];
+  return fields.every((f) => targetFields.includes(f));
+}
+
+// Signals that a concurrent identical request won the (requesterId,
+// idempotencyKey) insert race — not a ticketNumber collision, so it must not
+// be retried by generateTicketNumber; the route re-fetches and returns 200.
+class IdempotencyRaceError extends Error {}
+
+const IDEMPOTENCY_KEY_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ---------------------------------------------------------------------------
+// Issue 18 — Related System list
+// RelatedSystem mirrors the Category shape (api-spec.md §2): active rows
+// only, ordered by id. No header required (§0.1).
+// ---------------------------------------------------------------------------
+app.get("/api/related-systems", async (_req: Request, res: Response) => {
+  try {
+    const relatedSystems = await getPrisma().relatedSystem.findMany({
+      where: { isActive: true },
+      orderBy: { id: "asc" },
+      select: { id: true, name: true },
+    });
+    res.status(200).json(relatedSystems);
+  } catch (err) {
+    console.error("GET /api/related-systems failed:", err);
+    res.status(500).json({ error: "Unexpected server error" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Issue 18 — Create Ticket (api-spec.md §4)
+// ---------------------------------------------------------------------------
+app.post("/api/tickets", async (req: Request, res: Response) => {
+  try {
+    const requesterCheck = await checkRequester(req);
+    if (!requesterCheck.ok) {
+      return res.status(requesterCheck.status).json(requesterCheck.body);
+    }
+    const { requesterId } = requesterCheck;
+
+    // BR-11: Idempotency-Key is required and must be a valid UUID (any
+    // version).
+    const idempotencyKey = req.header("Idempotency-Key")?.trim();
+    if (!idempotencyKey || !IDEMPOTENCY_KEY_RE.test(idempotencyKey)) {
+      return res.status(400).json({
+        errors: [{ field: "Idempotency-Key", message: "Missing or invalid idempotency key" }],
+      });
+    }
+
+    // BR-11/BR-12: a replay of an already-used key returns the original
+    // Ticket — checked before body validation, since a replay must succeed
+    // even if the replayed body happens to be malformed.
+    const existing = await getPrisma().ticket.findUnique({
+      where: { requesterId_idempotencyKey: { requesterId, idempotencyKey } },
+    });
+    if (existing) {
+      return res.status(200).json(ticketToJSON(existing));
+    }
+
+    const validation = validateTicketInput(req.body);
+    if ("errors" in validation) {
+      return res.status(400).json({ errors: validation.errors });
+    }
+    const { value } = validation;
+
+    // BR-17: categoryId/relatedSystemId must reference a currently active
+    // row — an existence/active check, so it needs the DB and lives here
+    // rather than in ticketValidation.ts.
+    const [category, relatedSystem] = await Promise.all([
+      getPrisma().category.findUnique({ where: { id: value.categoryId } }),
+      getPrisma().relatedSystem.findUnique({ where: { id: value.relatedSystemId } }),
+    ]);
+    const fieldErrors: { field: string; message: string }[] = [];
+    if (!category || !category.isActive) {
+      fieldErrors.push({ field: "categoryId", message: "Category is not active" });
+    }
+    if (!relatedSystem || !relatedSystem.isActive) {
+      fieldErrors.push({ field: "relatedSystemId", message: "Related System is not active" });
+    }
+    if (fieldErrors.length > 0) {
+      return res.status(400).json({ errors: fieldErrors });
+    }
+
+    const year = new Date().getFullYear();
+    let createdTicket: Ticket | null = null;
+
+    const countCandidates = (y: number) =>
+      getPrisma().ticket.count({ where: { ticketNumber: { startsWith: `TKT-${y}-` } } });
+
+    const attemptInsert = async (candidate: string): Promise<boolean> => {
+      try {
+        createdTicket = await getPrisma().ticket.create({
+          data: {
+            ticketNumber: candidate,
+            requesterId,
+            categoryId: value.categoryId,
+            relatedSystemId: value.relatedSystemId,
+            summary: value.summary,
+            description: value.description,
+            requestedPriority: value.requestedPriority,
+            status: "NEW",
+            idempotencyKey,
+          },
+        });
+        return true;
+      } catch (err) {
+        // BR-38: a ticketNumber collision is retried with a new candidate.
+        if (isUniqueConstraintViolation(err, "ticketNumber")) return false;
+        // A different concurrent request won the idempotency race — not a
+        // ticketNumber collision, so don't retry; surface it to the outer
+        // catch below.
+        if (isUniqueConstraintViolation(err, "requesterId", "idempotencyKey")) {
+          throw new IdempotencyRaceError();
+        }
+        throw err;
+      }
+    };
+
+    try {
+      await generateTicketNumber(year, countCandidates, attemptInsert);
+    } catch (err) {
+      if (err instanceof IdempotencyRaceError) {
+        const raced = await getPrisma().ticket.findUnique({
+          where: { requesterId_idempotencyKey: { requesterId, idempotencyKey } },
+        });
+        if (raced) {
+          return res.status(200).json(ticketToJSON(raced));
+        }
+      }
+      throw err;
+    }
+
+    return res.status(201).json(ticketToJSON(createdTicket!));
+  } catch (err) {
+    console.error("POST /api/tickets failed:", err);
+    res.status(500).json({ error: "Unexpected server error" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Issue 18 — Upload Attachments (api-spec.md §7)
+// Upload only; download/preview/removal are a later Issue.
+// ---------------------------------------------------------------------------
+
+const ALLOWED_ATTACHMENT_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp", ".pdf"]);
+const ALLOWED_ATTACHMENT_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "application/pdf",
+]);
+const MAX_ATTACHMENT_SIZE_BYTES = 5 * 1024 * 1024;
+const MAX_ATTACHMENTS_PER_REQUEST = 5;
+const MAX_ACTIVE_ATTACHMENTS = 5;
+
+// limits.files is set generously above 5 so a >5-file request reaches the
+// handler intact and can be reported as a 409, rather than being silently
+// truncated by multer.
+const upload = multer({ storage: multer.memoryStorage(), limits: { files: 20 } });
+
+// A malformed multipart body (or a non-multipart Content-Type) makes multer
+// call back with an error; treated as the 400 "malformed request" case
+// rather than an unhandled server error.
+function handleAttachmentUpload(req: Request, res: Response, next: NextFunction) {
+  upload.array("files", 20)(req, res, (err: unknown) => {
+    if (err) {
+      return res.status(400).json({
+        errors: [{ field: "files", message: "Malformed upload request" }],
+      });
+    }
+    next();
+  });
+}
+
+app.post(
+  "/api/tickets/:id/attachments",
+  handleAttachmentUpload,
+  async (req: Request, res: Response) => {
+    try {
+      const requesterCheck = await checkRequester(req);
+      if (!requesterCheck.ok) {
+        return res.status(requesterCheck.status).json(requesterCheck.body);
+      }
+      const { requesterId } = requesterCheck;
+
+      const files = (req.files as Express.Multer.File[] | undefined) ?? [];
+
+      // 400 — malformed request only, checked before ownership/count/type/
+      // size (api-spec.md §7).
+      if (!/^\d+$/.test(req.params.id)) {
+        return res.status(400).json({
+          errors: [{ field: "id", message: "Ticket id must be an integer" }],
+        });
+      }
+      if (files.length === 0) {
+        return res.status(400).json({
+          errors: [{ field: "files", message: "At least one file is required" }],
+        });
+      }
+      const ticketId = Number(req.params.id);
+
+      // 404 — checked second, after 400, before 409 (api-spec.md §12 OQ-9).
+      const ticket = await getPrisma().ticket.findUnique({ where: { id: ticketId } });
+      if (!ticket || ticket.requesterId !== requesterId) {
+        return res.status(404).json({ error: "Not found" });
+      }
+
+      // 409 → 415 → 413 precedence (api-spec.md §7).
+      if (files.length > MAX_ATTACHMENTS_PER_REQUEST) {
+        return res.status(409).json({ error: "Too many files in this request" });
+      }
+
+      const activeCount = await getPrisma().attachment.count({
+        where: { ticketId, removedAt: null },
+      });
+      if (activeCount + files.length > MAX_ACTIVE_ATTACHMENTS) {
+        return res.status(409).json({ error: "Attachment limit reached" });
+      }
+
+      for (const file of files) {
+        const ext = path.extname(file.originalname).toLowerCase();
+        if (!ALLOWED_ATTACHMENT_EXTENSIONS.has(ext) || !ALLOWED_ATTACHMENT_MIME_TYPES.has(file.mimetype)) {
+          return res.status(415).json({ error: "Unsupported file type" });
+        }
+      }
+
+      for (const file of files) {
+        if (file.size > MAX_ATTACHMENT_SIZE_BYTES) {
+          return res.status(413).json({ error: "File exceeds 5 MB" });
+        }
+      }
+
+      // BR-30: nothing is stored or inserted until every check above passes.
+      const created: Attachment[] = [];
+      for (const file of files) {
+        const storedFilename = await storeUploadedFile(file.buffer, file.originalname);
+        const attachment = await getPrisma().attachment.create({
+          data: {
+            ticketId,
+            originalFilename: file.originalname,
+            storedFilename,
+            mimeType: file.mimetype,
+            sizeBytes: file.size,
+          },
+        });
+        created.push(attachment);
+      }
+
+      // BR-39: a successful upload touches the parent Ticket's updatedAt.
+      await getPrisma().ticket.update({ where: { id: ticketId }, data: {} });
+
+      return res.status(201).json(created.map(attachmentToJSON));
+    } catch (err) {
+      console.error(`POST /api/tickets/${req.params.id}/attachments failed:`, err);
+      res.status(500).json({ error: "Unexpected server error" });
+    }
+  },
+);
 
 export default app;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -297,12 +297,20 @@ const MAX_ACTIVE_ATTACHMENTS = 5;
 
 // limits.files is set generously above 5 so a >5-file request reaches the
 // handler intact and can be reported as a 409, rather than being silently
-// truncated by multer.
-const upload = multer({ storage: multer.memoryStorage(), limits: { files: 20 } });
+// truncated by multer. limits.fileSize is a coarse abuse guard well above
+// the real 5MB limit below, so a file this large is rejected by multer
+// before being fully buffered into memory; anything between 5MB and 20MB
+// still passes multer and is caught by the manual 413 check.
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { files: 20, fileSize: 20 * 1024 * 1024 },
+});
 
 // A malformed multipart body (or a non-multipart Content-Type) makes multer
 // call back with an error; treated as the 400 "malformed request" case
-// rather than an unhandled server error.
+// rather than an unhandled server error. This also covers a LIMIT_FILE_SIZE
+// error from the fileSize guard above — from the client's perspective it's
+// still just a bad request, not the 413 business-rule response below.
 function handleAttachmentUpload(req: Request, res: Response, next: NextFunction) {
   upload.array("files", 20)(req, res, (err: unknown) => {
     if (err) {

--- a/server/src/ticketNumber.ts
+++ b/server/src/ticketNumber.ts
@@ -1,0 +1,36 @@
+// Issue 18 — Ticket Number generation (BR-01, BR-38).
+
+const MAX_ATTEMPTS = 5;
+
+// BR-01: "TKT-YYYY-NNNNNN", sequence zero-padded to 6 digits.
+export function buildTicketNumber(year: number, seq: number): string {
+  return `TKT-${year}-${String(seq).padStart(6, "0")}`;
+}
+
+export class TicketNumberGenerationError extends Error {
+  constructor() {
+    super(`Unable to generate a unique ticket number after ${MAX_ATTEMPTS} attempts`);
+    this.name = "TicketNumberGenerationError";
+  }
+}
+
+// BR-38: on a ticketNumber unique-constraint collision, retry with a
+// recounted candidate, up to 5 attempts total. `countCandidates` and
+// `attemptInsert` are injected so this retry loop is unit-testable without a
+// real Prisma client — the caller (POST /api/tickets) supplies an
+// `attemptInsert` that performs the real Ticket insert and reports back
+// whether it collided (false) or succeeded (true); any other failure should
+// reject.
+export async function generateTicketNumber(
+  year: number,
+  countCandidates: (year: number) => Promise<number>,
+  attemptInsert: (ticketNumber: string) => Promise<boolean>,
+): Promise<string> {
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const count = await countCandidates(year);
+    const candidate = buildTicketNumber(year, count + 1);
+    const inserted = await attemptInsert(candidate);
+    if (inserted) return candidate;
+  }
+  throw new TicketNumberGenerationError();
+}

--- a/server/src/ticketValidation.ts
+++ b/server/src/ticketValidation.ts
@@ -1,0 +1,97 @@
+// Issue 18 — POST /api/tickets body validation (api-spec.md §4).
+// categoryId/relatedSystemId existence and active-row checks happen in the
+// route (server/src/app.ts), since they need the database.
+
+export interface FieldError {
+  field: string;
+  message: string;
+}
+
+export interface ValidTicketInput {
+  categoryId: number;
+  relatedSystemId: number;
+  summary: string;
+  description: string;
+  requestedPriority: "LOW" | "MEDIUM" | "HIGH";
+}
+
+const PRIORITIES = new Set(["LOW", "MEDIUM", "HIGH"]);
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value);
+}
+
+export function validateTicketInput(
+  body: unknown,
+): { errors: FieldError[] } | { value: ValidTicketInput } {
+  const errors: FieldError[] = [];
+  const b = typeof body === "object" && body !== null ? (body as Record<string, unknown>) : {};
+
+  let categoryId: number | undefined;
+  if (!isPositiveInteger(b.categoryId)) {
+    errors.push({ field: "categoryId", message: "Category is required" });
+  } else {
+    categoryId = b.categoryId;
+  }
+
+  let relatedSystemId: number | undefined;
+  if (!isPositiveInteger(b.relatedSystemId)) {
+    errors.push({ field: "relatedSystemId", message: "Related System is required" });
+  } else {
+    relatedSystemId = b.relatedSystemId;
+  }
+
+  // BR-14: trimmed before measuring length.
+  let summary: string | undefined;
+  if (typeof b.summary !== "string") {
+    errors.push({ field: "summary", message: "Summary is required" });
+  } else {
+    const trimmed = b.summary.trim();
+    if (trimmed.length === 0) {
+      errors.push({ field: "summary", message: "Summary is required" });
+    } else if (trimmed.length < 5 || trimmed.length > 120) {
+      errors.push({ field: "summary", message: "Summary must be between 5 and 120 characters" });
+    } else {
+      summary = trimmed;
+    }
+  }
+
+  let description: string | undefined;
+  if (typeof b.description !== "string") {
+    errors.push({ field: "description", message: "Description is required" });
+  } else {
+    const trimmed = b.description.trim();
+    if (trimmed.length === 0) {
+      errors.push({ field: "description", message: "Description is required" });
+    } else if (trimmed.length < 10 || trimmed.length > 2000) {
+      errors.push({
+        field: "description",
+        message: "Description must be between 10 and 2000 characters",
+      });
+    } else {
+      description = trimmed;
+    }
+  }
+
+  let requestedPriority: ValidTicketInput["requestedPriority"] | undefined;
+  if (typeof b.requestedPriority !== "string" || !PRIORITIES.has(b.requestedPriority)) {
+    errors.push({
+      field: "requestedPriority",
+      message: "Requested Priority must be LOW, MEDIUM, or HIGH",
+    });
+  } else {
+    requestedPriority = b.requestedPriority as ValidTicketInput["requestedPriority"];
+  }
+
+  if (errors.length > 0) return { errors };
+
+  return {
+    value: {
+      categoryId: categoryId!,
+      relatedSystemId: relatedSystemId!,
+      summary: summary!,
+      description: description!,
+      requestedPriority: requestedPriority!,
+    },
+  };
+}

--- a/server/src/uploads.ts
+++ b/server/src/uploads.ts
@@ -1,0 +1,19 @@
+// Issue 18 — Attachment file storage (api-spec.md §7).
+// Files are stored on local disk under server/uploads/ (gitignored) with a
+// randomly generated storedFilename; the download/removal endpoints that
+// read this directory back are a later Issue.
+
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const UPLOADS_DIR = path.join(__dirname, "..", "uploads");
+
+export async function storeUploadedFile(buffer: Buffer, originalFilename: string): Promise<string> {
+  await fs.mkdir(UPLOADS_DIR, { recursive: true });
+  const storedFilename = `${randomUUID()}${path.extname(originalFilename)}`;
+  await fs.writeFile(path.join(UPLOADS_DIR, storedFilename), buffer);
+  return storedFilename;
+}

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,333 @@
+import "./testDbEnv.js";
+
+import { randomUUID } from "node:crypto";
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverRoot = path.join(__dirname, "..", "..");
+
+// Imported dynamically, after testDbEnv.js has already pointed
+// process.env.DATABASE_URL at toktickit_test (src/prisma.ts's PrismaClient
+// singleton is lazy, but this keeps the ordering explicit either way).
+const { app } = await import("../../src/app.js");
+const { getPrisma } = await import("../../src/prisma.js");
+
+async function truncateAll() {
+  await getPrisma().$executeRawUnsafe(
+    `TRUNCATE TABLE "Attachment", "Ticket", "RequesterUser", "RelatedSystem", "Category" RESTART IDENTITY CASCADE;`,
+  );
+}
+
+async function seedCategory(name: string, isActive = true) {
+  return getPrisma().category.create({ data: { name, isActive } });
+}
+
+async function seedRelatedSystem(name: string, isActive = true) {
+  return getPrisma().relatedSystem.create({ data: { name, isActive } });
+}
+
+async function seedRequester(name: string, email: string, isActive = true) {
+  return getPrisma().requesterUser.create({ data: { name, email, isActive } });
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    categoryId: 1,
+    relatedSystemId: 1,
+    summary: "Laptop won't power on",
+    description: "Screen stays black after the firmware update finished overnight.",
+    requestedPriority: "HIGH",
+    ...overrides,
+  };
+}
+
+describe("Create Ticket", () => {
+  beforeAll(() => {
+    execSync("npx prisma migrate deploy --schema=prisma/schema.prisma", {
+      cwd: serverRoot,
+      stdio: "inherit",
+      env: process.env,
+    });
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  afterAll(async () => {
+    await getPrisma().$disconnect();
+    // Prevents this override from leaking into a lab-01 test file that
+    // might share this worker's process.env afterward.
+    delete process.env.DATABASE_URL;
+  });
+
+  // API-01
+  it("GET /api/categories returns active Categories only, ordered by id", async () => {
+    await seedCategory("Hardware", true);
+    await seedCategory("Retired Category", false);
+    await seedCategory("Software", true);
+
+    const res = await request(app).get("/api/categories");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { id: 1, name: "Hardware" },
+      { id: 3, name: "Software" },
+    ]);
+  });
+
+  // API-02
+  it("GET /api/related-systems returns active Related Systems only, ordered by id", async () => {
+    await seedRelatedSystem("Email", true);
+    await seedRelatedSystem("Retired System", false);
+    await seedRelatedSystem("VPN", true);
+
+    const res = await request(app).get("/api/related-systems");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { id: 1, name: "Email" },
+      { id: 3, name: "VPN" },
+    ]);
+  });
+
+  // API-04
+  it("POST /api/tickets with a valid body returns 201 with a generated ticket number", async () => {
+    await seedCategory("Hardware");
+    await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requester.id))
+      .set("Idempotency-Key", randomUUID())
+      .send(validBody());
+
+    expect(res.status).toBe(201);
+    expect(res.body.ticketNumber).toMatch(/^TKT-\d{4}-\d{6}$/);
+    expect(res.body.status).toBe("NEW");
+    expect(res.body.requesterId).toBe(requester.id);
+  });
+
+  // API-05
+  it("POST /api/tickets without X-Requester-Id returns 400", async () => {
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("Idempotency-Key", randomUUID())
+      .send(validBody());
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual([
+      { field: "X-Requester-Id", message: "Missing or invalid requester header" },
+    ]);
+  });
+
+  // API-06
+  it("POST /api/tickets with a header that isn't an active Requester returns 403", async () => {
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", "999")
+      .set("Idempotency-Key", randomUUID())
+      .send(validBody());
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Selected Requester is not active" });
+  });
+
+  // API-07
+  it("POST /api/tickets with an empty Summary returns 400 and creates no Ticket", async () => {
+    await seedCategory("Hardware");
+    await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requester.id))
+      .set("Idempotency-Key", randomUUID())
+      .send(validBody({ summary: "" }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: "summary" })]),
+    );
+    expect(await getPrisma().ticket.count()).toBe(0);
+  });
+
+  // API-08
+  it("POST /api/tickets with Description below the 10-char minimum returns 400", async () => {
+    await seedCategory("Hardware");
+    await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requester.id))
+      .set("Idempotency-Key", randomUUID())
+      .send(validBody({ description: "a".repeat(9) }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: "description" })]),
+    );
+  });
+
+  // API-09
+  it("POST /api/tickets with a deactivated Category returns 400 on categoryId", async () => {
+    const category = await seedCategory("Retired Category", false);
+    await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requester.id))
+      .set("Idempotency-Key", randomUUID())
+      .send(validBody({ categoryId: category.id }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: "categoryId" })]),
+    );
+  });
+
+  // API-10
+  it("POST /api/tickets with a nonexistent relatedSystemId returns 400", async () => {
+    await seedCategory("Hardware");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requester.id))
+      .set("Idempotency-Key", randomUUID())
+      .send(validBody({ relatedSystemId: 999 }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: "relatedSystemId" })]),
+    );
+  });
+
+  // API-11
+  it('POST /api/tickets with requestedPriority "URGENT" returns 400', async () => {
+    await seedCategory("Hardware");
+    await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requester.id))
+      .set("Idempotency-Key", randomUUID())
+      .send(validBody({ requestedPriority: "URGENT" }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: "requestedPriority" })]),
+    );
+  });
+
+  // API-12
+  it("POST /api/tickets replays an already-used Idempotency-Key as a 200 with the original Ticket", async () => {
+    await seedCategory("Hardware");
+    await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const idempotencyKey = randomUUID();
+
+    const first = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requester.id))
+      .set("Idempotency-Key", idempotencyKey)
+      .send(validBody());
+    expect(first.status).toBe(201);
+
+    const second = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requester.id))
+      .set("Idempotency-Key", idempotencyKey)
+      .send(validBody());
+
+    expect(second.status).toBe(200);
+    expect(second.body.id).toBe(first.body.id);
+    expect(second.body.ticketNumber).toBe(first.body.ticketNumber);
+    expect(await getPrisma().ticket.count()).toBe(1);
+  });
+
+  // API-13
+  it("POST /api/tickets with the same Idempotency-Key from a different Requester creates a distinct Ticket", async () => {
+    await seedCategory("Hardware");
+    await seedRelatedSystem("Email");
+    const alex = await seedRequester("Alex Rivera", "alex@example.com");
+    const sam = await seedRequester("Sam Okafor", "sam@example.com");
+    const idempotencyKey = randomUUID();
+
+    const first = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(alex.id))
+      .set("Idempotency-Key", idempotencyKey)
+      .send(validBody());
+    expect(first.status).toBe(201);
+
+    const second = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(sam.id))
+      .set("Idempotency-Key", idempotencyKey)
+      .send(validBody());
+
+    expect(second.status).toBe(201);
+    expect(second.body.id).not.toBe(first.body.id);
+    expect(await getPrisma().ticket.count()).toBe(2);
+  });
+
+  // API-14 — property test against the real DB unique constraint: two
+  // Promise.all-parallel requests sharing one Idempotency-Key. This proves
+  // the constraint (not just application logic) enforces BR-11/BR-12; the
+  // exact request that "wins" isn't deterministic, but exactly one row
+  // must exist afterward regardless of interleaving (tests.md §7).
+  it("two concurrent POSTs sharing one Idempotency-Key create exactly one Ticket", async () => {
+    await seedCategory("Hardware");
+    await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const idempotencyKey = randomUUID();
+
+    const [first, second] = await Promise.all([
+      request(app)
+        .post("/api/tickets")
+        .set("X-Requester-Id", String(requester.id))
+        .set("Idempotency-Key", idempotencyKey)
+        .send(validBody()),
+      request(app)
+        .post("/api/tickets")
+        .set("X-Requester-Id", String(requester.id))
+        .set("Idempotency-Key", idempotencyKey)
+        .send(validBody()),
+    ]);
+
+    expect([first.status, second.status].sort()).toEqual([200, 201]);
+    expect(first.body.id).toBe(second.body.id);
+    expect(await getPrisma().ticket.count()).toBe(1);
+  });
+
+  // API-15
+  it("POST /api/tickets rejects Summary at 121 chars and Description at 2001 chars", async () => {
+    await seedCategory("Hardware");
+    await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requester.id))
+      .set("Idempotency-Key", randomUUID())
+      .send(
+        validBody({
+          summary: "a".repeat(121),
+          description: "a".repeat(2001),
+        }),
+      );
+
+    expect(res.status).toBe(400);
+    const fields = res.body.errors.map((e: { field: string }) => e.field).sort();
+    expect(fields).toEqual(["description", "summary"]);
+  });
+});

--- a/server/tests/lab-02/testDbEnv.ts
+++ b/server/tests/lab-02/testDbEnv.ts
@@ -1,0 +1,45 @@
+// tests.md §5.1 — points this file's Prisma connection at the dedicated
+// toktickit_test database instead of the dev database in server/.env.
+// Imported first (for its side effect only) by every lab-02 API test file,
+// so process.env.DATABASE_URL is already overridden before src/prisma.ts's
+// lazy PrismaClient singleton is ever constructed. Deliberately scoped to
+// lab-02 test files only (not wired into vitest.config.ts globally) so the
+// pre-existing tests/lab-01 suite keeps running against the seeded dev
+// database untouched.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const envTestPath = path.join(__dirname, "..", "..", ".env.test");
+
+function loadEnvTest(): Record<string, string> {
+  const vars: Record<string, string> = {};
+  let contents: string;
+  try {
+    contents = readFileSync(envTestPath, "utf-8");
+  } catch {
+    throw new Error(
+      `Missing ${envTestPath} — create it per tests.md §5.1, pointing DATABASE_URL at toktickit_test.`,
+    );
+  }
+  for (const rawLine of contents.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    vars[key] = value;
+  }
+  return vars;
+}
+
+Object.assign(process.env, loadEnvTest());

--- a/server/tests/lab-02/ticket-number.unit.test.ts
+++ b/server/tests/lab-02/ticket-number.unit.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTicketNumber,
+  generateTicketNumber,
+  TicketNumberGenerationError,
+} from "../../src/ticketNumber.js";
+
+describe("buildTicketNumber", () => {
+  // UNIT-01
+  it("zero-pads the sequence to 6 digits and includes the correct year", () => {
+    expect(buildTicketNumber(2026, 1)).toBe("TKT-2026-000001");
+    expect(buildTicketNumber(2026, 42)).toBe("TKT-2026-000042");
+    expect(buildTicketNumber(2026, 123456)).toBe("TKT-2026-123456");
+  });
+});
+
+describe("generateTicketNumber", () => {
+  // UNIT-02
+  it("retries on a mocked unique-constraint collision, up to 5 attempts, then gives up", async () => {
+    let attempts = 0;
+    const countCandidates = async () => 0; // always proposes seq 1
+    const attemptInsert = async () => {
+      attempts += 1;
+      return false; // every attempt collides
+    };
+
+    await expect(generateTicketNumber(2026, countCandidates, attemptInsert)).rejects.toThrow(
+      TicketNumberGenerationError,
+    );
+    expect(attempts).toBe(5);
+  });
+
+  it("returns the winning candidate once attemptInsert reports success", async () => {
+    let attempts = 0;
+    const countCandidates = async () => attempts; // count grows as retries happen
+    const attemptInsert = async () => {
+      attempts += 1;
+      return attempts === 3; // succeeds on the 3rd try
+    };
+
+    const result = await generateTicketNumber(2026, countCandidates, attemptInsert);
+
+    expect(result).toBe("TKT-2026-000003");
+    expect(attempts).toBe(3);
+  });
+});

--- a/server/tests/lab-02/ticket-validation.unit.test.ts
+++ b/server/tests/lab-02/ticket-validation.unit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { validateTicketInput, type ValidTicketInput } from "../../src/ticketValidation.js";
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    categoryId: 1,
+    relatedSystemId: 1,
+    summary: "Laptop won't power on",
+    description: "Screen stays black after the firmware update.",
+    requestedPriority: "MEDIUM",
+    ...overrides,
+  };
+}
+
+function fieldNames(result: ReturnType<typeof validateTicketInput>): string[] {
+  if (!("errors" in result)) return [];
+  return result.errors.map((e) => e.field);
+}
+
+describe("validateTicketInput", () => {
+  // UNIT-03
+  it("trims Summary/Description before measuring length (BR-14)", () => {
+    const result = validateTicketInput(
+      validBody({ summary: "  hi  ", description: "a".repeat(10) }),
+    );
+
+    // Trimmed "hi" is length 2, below the 5-char minimum — fails.
+    expect(fieldNames(result)).toContain("summary");
+  });
+
+  it("stores the trimmed value on success", () => {
+    const result = validateTicketInput(validBody({ summary: "  Hello there  " }));
+
+    expect("value" in result).toBe(true);
+    expect((result as { value: ValidTicketInput }).value.summary).toBe("Hello there");
+  });
+
+  // UNIT-04
+  it("enforces the Summary length boundary: 4 fails, 5 passes, 120 passes, 121 fails", () => {
+    expect(fieldNames(validateTicketInput(validBody({ summary: "a".repeat(4) })))).toContain(
+      "summary",
+    );
+    expect(fieldNames(validateTicketInput(validBody({ summary: "a".repeat(5) })))).not.toContain(
+      "summary",
+    );
+    expect(fieldNames(validateTicketInput(validBody({ summary: "a".repeat(120) })))).not.toContain(
+      "summary",
+    );
+    expect(fieldNames(validateTicketInput(validBody({ summary: "a".repeat(121) })))).toContain(
+      "summary",
+    );
+  });
+
+  // UNIT-05
+  it("enforces the Description length boundary: 9 fails, 10 passes, 2000 passes, 2001 fails", () => {
+    expect(
+      fieldNames(validateTicketInput(validBody({ description: "a".repeat(9) }))),
+    ).toContain("description");
+    expect(
+      fieldNames(validateTicketInput(validBody({ description: "a".repeat(10) }))),
+    ).not.toContain("description");
+    expect(
+      fieldNames(validateTicketInput(validBody({ description: "a".repeat(2000) }))),
+    ).not.toContain("description");
+    expect(
+      fieldNames(validateTicketInput(validBody({ description: "a".repeat(2001) }))),
+    ).toContain("description");
+  });
+
+  it("returns every failing field in one pass, not just the first", () => {
+    const result = validateTicketInput({
+      categoryId: "not-a-number",
+      relatedSystemId: null,
+      summary: "",
+      description: "too short",
+      requestedPriority: "URGENT",
+    });
+
+    expect(fieldNames(result).sort()).toEqual(
+      ["categoryId", "description", "relatedSystemId", "requestedPriority", "summary"].sort(),
+    );
+  });
+
+  it("requires requestedPriority to be LOW, MEDIUM, or HIGH", () => {
+    expect(fieldNames(validateTicketInput(validBody({ requestedPriority: "URGENT" })))).toContain(
+      "requestedPriority",
+    );
+    expect(fieldNames(validateTicketInput(validBody({ requestedPriority: "LOW" })))).not.toContain(
+      "requestedPriority",
+    );
+  });
+});


### PR DESCRIPTION
Closes #18

## What this adds

- `POST /api/tickets` — validation, `X-Requester-Id`/`Idempotency-Key`
  handling, active-Category/RelatedSystem checks, ticket-number
  generation with retry on collision (BR-38)
- `GET /api/related-systems`
- `POST /api/tickets/:id/attachments` — upload only, 409→415→413
  precedence, atomic per batch (BR-30)
- `CreateTicketForm`, `Field`, `AttachmentPicker` components
- Mounted at `/tickets/new`, replacing the placeholder

## Scope note: attachment upload moved into this Issue

`ui-spec.md` §7 and BR-20 require Create Ticket to upload attachments as
a second call after the Ticket is created, so a failed upload doesn't
fail the Ticket. That second call is `POST /api/tickets/:id/attachments`,
originally scoped to Issue #21. It's built here instead, upload only.
Issue #21 will add download/preview and soft-remove on top of the same
endpoint family — I'll update its Issue body to reflect that before we
start it.

## Two things worth a close look

1. Idempotency replay is checked before body validation, so a retried
   request with a malformed body still returns the original Ticket
   (api-spec.md §4). A concurrent identical request that loses the
   ticket-number retry race is caught separately and re-fetched as a
   200, not a 500.
2. `POST /api/tickets/:id/attachments` checks ownership (404) before
   the 409 file-count checks, per `api-spec.md` §12 OQ-9. Malformed
   `:id` or an empty file list returns 400 before either.

## Test infra added

`server/.env.test` (gitignored) points at a `toktickit_test` Postgres
database created locally; truncation between tests is scoped to
`server/tests/lab-02/create-ticket.api.test.ts` only, not wired globally
into `vitest.config.ts`, so it can't race with or empty the tables the
existing `tests/lab-01/categories.test.ts` depends on.

## Verified locally

- `npx tsc --noEmit` — clean
- `npm run build` — succeeds
- Server tests: unit (ticket number, validation) and API (14 cases
  incl. the idempotency race, stable across repeated runs) — all pass
- Client tests: `CreateTicketForm` (UI-07–13), `AttachmentPicker`
  (UI-14–17) — all pass, fetch mocked, no real network
- No `.js` files emitted under `client/src` or `client/tests`
- `server/uploads/` confirmed gitignored, not tracked
