### PR TITLE
feat(lab-02): My Tickets

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import AppShell from "./components/AppShell.js";
 import RequesterSelect from "./screens/RequesterSelect.js";
 import CreateTicketForm from "./screens/CreateTicketForm.js";
+import MyTickets from "./screens/MyTickets.js";
 import { RequesterProvider, useRequester } from "./lib/requesterContext.js";
 
 // AC-02: /tickets, /tickets/new, /tickets/:id redirect here when nothing is
@@ -13,10 +14,6 @@ function RequireRequester({ children }: { children: ReactNode }) {
     return <Navigate to="/select-requester" replace />;
   }
   return <>{children}</>;
-}
-
-function MyTicketsPlaceholder() {
-  return <h1>My Tickets</h1>;
 }
 
 function TicketDetailPlaceholder() {
@@ -39,7 +36,7 @@ export default function App() {
             element={
               <RequireRequester>
                 <AppShell>
-                  <MyTicketsPlaceholder />
+                  <MyTickets />
                 </AppShell>
               </RequireRequester>
             }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -127,6 +127,49 @@ export async function createTicket(
   throw new Error(`Create ticket failed with status ${res.status}`);
 }
 
+// api-spec.md §5 — the shared pagination-metadata shape.
+export interface TicketListResult {
+  data: Ticket[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  totalPages: number;
+}
+
+export interface TicketListParams {
+  search?: string;
+  categoryId?: number;
+  requestedPriority?: Priority;
+  status?: "NEW";
+  sortBy?: string;
+  sortDir?: "asc" | "desc";
+  page?: number;
+  pageSize?: number;
+}
+
+// Issue 19 — My Tickets list (api-spec.md §5). Every control on this screen
+// only ever sends values it itself defined, so a 400 here is a programming
+// error, not user input to fix inline — thrown like any other non-2xx
+// status rather than returned as data.
+export async function getTickets(params: TicketListParams): Promise<TicketListResult> {
+  const query = new URLSearchParams();
+  if (params.search !== undefined) query.set("search", params.search);
+  if (params.categoryId !== undefined) query.set("categoryId", String(params.categoryId));
+  if (params.requestedPriority !== undefined) query.set("requestedPriority", params.requestedPriority);
+  if (params.status !== undefined) query.set("status", params.status);
+  if (params.sortBy !== undefined) query.set("sortBy", params.sortBy);
+  if (params.sortDir !== undefined) query.set("sortDir", params.sortDir);
+  if (params.page !== undefined) query.set("page", String(params.page));
+  if (params.pageSize !== undefined) query.set("pageSize", String(params.pageSize));
+
+  const qs = query.toString();
+  const res = await apiFetch(`/api/tickets${qs ? `?${qs}` : ""}`);
+  if (!res.ok) {
+    throw new Error(`Tickets fetch failed with status ${res.status}`);
+  }
+  return (await res.json()) as TicketListResult;
+}
+
 // Issue 18 — upload up to 5 files to an existing owned Ticket
 // (api-spec.md §7, upload only). Throws on any non-2xx status; a failed
 // upload doesn't fail the Ticket that was already created (BR-20).

--- a/client/src/components/Pagination.tsx
+++ b/client/src/components/Pagination.tsx
@@ -1,0 +1,45 @@
+interface PaginationProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+// ui-spec.md §13.5, §19 — this dataset never exceeds 3 pages (25 seeded
+// Tickets max, 10/page min), so every page button renders, no ellipsis.
+export default function Pagination({ page, totalPages, onPageChange }: PaginationProps) {
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  return (
+    <nav className="pagination" aria-label="Pagination">
+      <button
+        type="button"
+        className="btn btn--tertiary pagination__prev"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+      >
+        Previous
+      </button>
+
+      {pages.map((p) => (
+        <button
+          key={p}
+          type="button"
+          className={`btn btn--tertiary pagination__page-btn${p === page ? " pagination__page-btn--active" : ""}`}
+          aria-current={p === page ? "page" : undefined}
+          onClick={() => onPageChange(p)}
+        >
+          {p}
+        </button>
+      ))}
+
+      <button
+        type="button"
+        className="btn btn--tertiary pagination__next"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+      >
+        Next
+      </button>
+    </nav>
+  );
+}

--- a/client/src/lib/sortDefaults.ts
+++ b/client/src/lib/sortDefaults.ts
@@ -1,0 +1,14 @@
+// ui-spec.md §13.2 / OQ-UI-2 — default sortDir when a column is picked as
+// sortBy for the first time.
+export type SortableTicketField = "createdAt" | "summary" | "requestedPriority" | "status";
+
+const DEFAULT_SORT_DIR: Record<SortableTicketField, "asc" | "desc"> = {
+  createdAt: "desc",
+  summary: "asc",
+  requestedPriority: "desc",
+  status: "desc",
+};
+
+export function defaultSortDir(sortBy: SortableTicketField): "asc" | "desc" {
+  return DEFAULT_SORT_DIR[sortBy];
+}

--- a/client/src/screens/MyTickets.tsx
+++ b/client/src/screens/MyTickets.tsx
@@ -1,0 +1,404 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  getCategories,
+  getTickets,
+  type Category,
+  type Priority,
+  type Ticket,
+  type TicketListParams,
+  type TicketListResult,
+} from "../api.js";
+import { defaultSortDir, type SortableTicketField } from "../lib/sortDefaults.js";
+import Badge from "../components/Badge.js";
+import Pagination from "../components/Pagination.js";
+import StateBanner from "../components/StateBanner.js";
+
+type LoadState = "loading" | "loaded" | "error";
+
+const PAGE_SIZE_OPTIONS = [10, 20, 50];
+
+const SORT_OPTIONS: { value: string; label: string; sortBy: SortableTicketField; sortDir: "asc" | "desc" }[] = [
+  { value: "createdAt-desc", label: "Created Date (Newest First)", sortBy: "createdAt", sortDir: "desc" },
+  { value: "createdAt-asc", label: "Created Date (Oldest First)", sortBy: "createdAt", sortDir: "asc" },
+  { value: "summary-asc", label: "Summary (A–Z)", sortBy: "summary", sortDir: "asc" },
+  { value: "summary-desc", label: "Summary (Z–A)", sortBy: "summary", sortDir: "desc" },
+  { value: "requestedPriority-desc", label: "Requested Priority (High First)", sortBy: "requestedPriority", sortDir: "desc" },
+  { value: "requestedPriority-asc", label: "Requested Priority (Low First)", sortBy: "requestedPriority", sortDir: "asc" },
+  { value: "status-desc", label: "Current Status (Z–A)", sortBy: "status", sortDir: "desc" },
+  { value: "status-asc", label: "Current Status (A–Z)", sortBy: "status", sortDir: "asc" },
+];
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString();
+}
+
+function SortIcon({ active, dir }: { active: boolean; dir: "asc" | "desc" }) {
+  return (
+    <span className="ticket-table__sort-icon" aria-hidden="true">
+      {active ? (dir === "asc" ? "▲" : "▼") : ""}
+    </span>
+  );
+}
+
+export default function MyTickets() {
+  const navigate = useNavigate();
+
+  const [categories, setCategories] = useState<Category[]>([]);
+
+  const [searchInput, setSearchInput] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [categoryIdFilter, setCategoryIdFilter] = useState("");
+  const [priorityFilter, setPriorityFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+
+  const [sortBy, setSortBy] = useState<SortableTicketField>("createdAt");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+  const [result, setResult] = useState<TicketListResult | null>(null);
+
+  useEffect(() => {
+    getCategories()
+      .then(setCategories)
+      .catch(() => {});
+  }, []);
+
+  // ui-spec.md §13.1 — ~300ms debounce before triggering a refetch.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchInput), 300);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const params: TicketListParams = useMemo(
+    () => ({
+      search: debouncedSearch || undefined,
+      categoryId: categoryIdFilter ? Number(categoryIdFilter) : undefined,
+      requestedPriority: priorityFilter ? (priorityFilter as Priority) : undefined,
+      status: statusFilter ? "NEW" : undefined,
+      sortBy,
+      sortDir,
+      page,
+      pageSize,
+    }),
+    [debouncedSearch, categoryIdFilter, priorityFilter, statusFilter, sortBy, sortDir, page, pageSize],
+  );
+
+  // A page number left over from a more-filtered view can point past the
+  // end of a less-filtered result set — e.g. on page 2 of a category
+  // filter, then the filter is loosened to one page's worth of tickets.
+  // Without resetting, that stale page returns an empty page of real data,
+  // which would misrender as the zero-tickets Empty state.
+  useEffect(() => {
+    setPage(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch, categoryIdFilter, priorityFilter, statusFilter]);
+
+  const load = useCallback(() => {
+    setLoadState("loading");
+    getTickets(params)
+      .then((res) => {
+        setResult(res);
+        setLoadState("loaded");
+      })
+      .catch(() => {
+        setLoadState("error");
+      });
+  }, [params]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  function handleSortClick(field: SortableTicketField) {
+    if (field === sortBy) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(field);
+      setSortDir(defaultSortDir(field));
+    }
+  }
+
+  function handleMobileSortChange(value: string) {
+    const option = SORT_OPTIONS.find((o) => o.value === value);
+    if (!option) return;
+    setSortBy(option.sortBy);
+    setSortDir(option.sortDir);
+  }
+
+  function handlePageSizeChange(value: string) {
+    setPageSize(Number(value));
+    setPage(1);
+  }
+
+  function handleClearFilters() {
+    setSearchInput("");
+    setDebouncedSearch("");
+    setCategoryIdFilter("");
+    setPriorityFilter("");
+    setStatusFilter("");
+    setPage(1);
+  }
+
+  const hasAnyFilterInput = Boolean(searchInput || categoryIdFilter || priorityFilter || statusFilter);
+  const hasCommittedFilter = Boolean(debouncedSearch || categoryIdFilter || priorityFilter || statusFilter);
+
+  const isEmptyState = loadState === "loaded" && result !== null && result.data.length === 0 && !hasCommittedFilter;
+  const isNoResultsState = loadState === "loaded" && result !== null && result.data.length === 0 && hasCommittedFilter;
+
+  function categoryName(categoryId: number): string {
+    return categories.find((c) => c.id === categoryId)?.name ?? String(categoryId);
+  }
+
+  const start = result && result.totalCount > 0 ? (result.page - 1) * result.pageSize + 1 : 0;
+  const end = result ? Math.min(result.page * result.pageSize, result.totalCount) : 0;
+
+  return (
+    <div className="my-tickets">
+      <h1>My Tickets</h1>
+
+      {!isEmptyState && (
+        <div className="ticket-toolbar">
+          <input
+            type="text"
+            className="ticket-toolbar__search"
+            placeholder="Search by ticket number or summary…"
+            aria-label="Search"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+          />
+
+          <select
+            className="ticket-toolbar__filter"
+            aria-label="Category"
+            value={categoryIdFilter}
+            onChange={(e) => setCategoryIdFilter(e.target.value)}
+          >
+            <option value="">All Categories</option>
+            {categories.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+
+          <select
+            className="ticket-toolbar__filter"
+            aria-label="Requested Priority"
+            value={priorityFilter}
+            onChange={(e) => setPriorityFilter(e.target.value)}
+          >
+            <option value="">All Priorities</option>
+            <option value="LOW">Low</option>
+            <option value="MEDIUM">Medium</option>
+            <option value="HIGH">High</option>
+          </select>
+
+          <select
+            className="ticket-toolbar__filter"
+            aria-label="Current Status"
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+          >
+            <option value="">All Statuses</option>
+            <option value="NEW">New</option>
+          </select>
+
+          <select
+            className="ticket-toolbar__page-size"
+            aria-label="Page Size"
+            value={pageSize}
+            onChange={(e) => handlePageSizeChange(e.target.value)}
+          >
+            {PAGE_SIZE_OPTIONS.map((size) => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </select>
+
+          <select
+            className="ticket-toolbar__sort-select"
+            aria-label="Sort by"
+            value={`${sortBy}-${sortDir}`}
+            onChange={(e) => handleMobileSortChange(e.target.value)}
+          >
+            {SORT_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+
+          <button
+            type="button"
+            className="btn btn--secondary ticket-toolbar__clear-filters-btn"
+            disabled={!hasAnyFilterInput}
+            aria-disabled={!hasAnyFilterInput}
+            onClick={handleClearFilters}
+          >
+            Clear Filters
+          </button>
+
+          <button type="button" className="btn btn--primary" onClick={() => navigate("/tickets/new")}>
+            Create Ticket
+          </button>
+        </div>
+      )}
+
+      {loadState === "error" && (
+        <StateBanner variant="error">
+          <p>Couldn't load Tickets.</p>
+          <button type="button" className="btn btn--secondary" onClick={load}>
+            Retry
+          </button>
+        </StateBanner>
+      )}
+
+      {loadState !== "error" && isEmptyState && (
+        <StateBanner variant="empty">
+          <h2>No tickets yet</h2>
+          <p>Create your first ticket to get started.</p>
+          <button type="button" className="btn btn--primary" onClick={() => navigate("/tickets/new")}>
+            Create Ticket
+          </button>
+        </StateBanner>
+      )}
+
+      {loadState !== "error" && isNoResultsState && (
+        <StateBanner variant="no-results">
+          <h2>No tickets match your search</h2>
+          <p>Try adjusting or clearing your filters.</p>
+          <button type="button" className="btn btn--secondary" onClick={handleClearFilters}>
+            Clear Filters
+          </button>
+        </StateBanner>
+      )}
+
+      {loadState !== "error" && !isEmptyState && !isNoResultsState && (
+        <>
+          <table className="ticket-table">
+            <thead>
+              <tr>
+                <th>Ticket No.</th>
+                <th className="ticket-table__header--sortable">
+                  <button type="button" className="btn btn--tertiary" onClick={() => handleSortClick("createdAt")}>
+                    Created Date
+                    <SortIcon active={sortBy === "createdAt"} dir={sortDir} />
+                  </button>
+                </th>
+                <th className="ticket-table__header--sortable">
+                  <button type="button" className="btn btn--tertiary" onClick={() => handleSortClick("summary")}>
+                    Summary
+                    <SortIcon active={sortBy === "summary"} dir={sortDir} />
+                  </button>
+                </th>
+                <th>Category</th>
+                <th className="ticket-table__header--sortable">
+                  <button
+                    type="button"
+                    className="btn btn--tertiary"
+                    onClick={() => handleSortClick("requestedPriority")}
+                  >
+                    Requested Priority
+                    <SortIcon active={sortBy === "requestedPriority"} dir={sortDir} />
+                  </button>
+                </th>
+                <th className="ticket-table__header--sortable">
+                  <button type="button" className="btn btn--tertiary" onClick={() => handleSortClick("status")}>
+                    Current Status
+                    <SortIcon active={sortBy === "status"} dir={sortDir} />
+                  </button>
+                </th>
+                <th>Last Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loadState === "loading"
+                ? Array.from({ length: 3 }).map((_, i) => (
+                    <tr key={i} className="ticket-table__row--skeleton" data-testid="ticket-skeleton-row">
+                      <td colSpan={7}>&nbsp;</td>
+                    </tr>
+                  ))
+                : (result?.data ?? []).map((t: Ticket) => (
+                    <tr
+                      key={t.id}
+                      className="ticket-table__row"
+                      onClick={() => navigate(`/tickets/${t.id}`)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") navigate(`/tickets/${t.id}`);
+                      }}
+                      tabIndex={0}
+                    >
+                      <td>{t.ticketNumber}</td>
+                      <td>{formatDate(t.createdAt)}</td>
+                      <td>{t.summary}</td>
+                      <td>{categoryName(t.categoryId)}</td>
+                      <td onClick={(e) => e.stopPropagation()}>
+                        <Badge kind="priority" value={t.requestedPriority} />
+                      </td>
+                      <td onClick={(e) => e.stopPropagation()}>
+                        <Badge kind="status" value={t.status} />
+                      </td>
+                      <td>{formatDate(t.updatedAt)}</td>
+                    </tr>
+                  ))}
+            </tbody>
+          </table>
+
+          <div className="ticket-card-list">
+            {loadState === "loading"
+              ? Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="ticket-card ticket-card--skeleton" data-testid="ticket-skeleton-card" />
+                ))
+              : (result?.data ?? []).map((t: Ticket) => (
+                  <div
+                    key={t.id}
+                    className="ticket-card"
+                    onClick={() => navigate(`/tickets/${t.id}`)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") navigate(`/tickets/${t.id}`);
+                    }}
+                    tabIndex={0}
+                  >
+                    <div className="ticket-card__header-row">
+                      <span className="ticket-card__ticket-number">{t.ticketNumber}</span>
+                      <span className="ticket-card__priority-badge" onClick={(e) => e.stopPropagation()}>
+                        <Badge kind="priority" value={t.requestedPriority} />
+                      </span>
+                    </div>
+                    <p className="ticket-card__title">{t.summary}</p>
+                    <div className="ticket-card__secondary-row">
+                      <span>{categoryName(t.categoryId)}</span>
+                      <span className="ticket-card__status-badge" onClick={(e) => e.stopPropagation()}>
+                        <Badge kind="status" value={t.status} />
+                      </span>
+                    </div>
+                    <div className="ticket-card__footer-row">
+                      <span>
+                        <span className="ticket-card__footer-label">Created</span> {formatDate(t.createdAt)}
+                      </span>
+                      <span>
+                        <span className="ticket-card__footer-label">Updated</span> {formatDate(t.updatedAt)}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+          </div>
+
+          {loadState === "loaded" && result && (
+            <>
+              <p className="ticket-list__pagination-summary">
+                Showing {start}–{end} of {result.totalCount}
+              </p>
+              <Pagination page={result.page} totalPages={result.totalPages} onPageChange={setPage} />
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/styles/components.css
+++ b/client/src/styles/components.css
@@ -471,3 +471,195 @@ textarea.field__control {
     grid-template-columns: 1fr;
   }
 }
+
+/* ---------------------------------------------------------------------- */
+/* My Tickets — ui-spec.md §13, §19                                       */
+/* ---------------------------------------------------------------------- */
+
+.my-tickets {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.ticket-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.ticket-toolbar__search {
+  height: var(--control-height);
+  padding: 0 var(--space-md);
+  border-radius: var(--radius-control);
+  border: 1px solid var(--color-field-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-body);
+  flex: 1 1 240px;
+  min-width: 180px;
+}
+
+.ticket-toolbar__filter,
+.ticket-toolbar__page-size,
+.ticket-toolbar__sort-select {
+  height: var(--control-height);
+  padding: 0 var(--space-md);
+  border-radius: var(--radius-control);
+  border: 1px solid var(--color-field-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-body);
+}
+
+.ticket-toolbar__sort-select {
+  display: none;
+}
+
+/* ---------------------------------------------------------------------- */
+/* My Tickets — desktop table (>= 768px)                                  */
+/* ---------------------------------------------------------------------- */
+
+.ticket-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--color-surface);
+  border-radius: var(--radius-control);
+  overflow: hidden;
+}
+
+.ticket-table th,
+.ticket-table td {
+  padding: var(--space-sm) var(--space-md);
+  text-align: left;
+  border-bottom: 1px solid var(--color-field-border);
+  font-size: var(--font-size-body);
+}
+
+.ticket-table__header--sortable {
+  padding: 0;
+}
+
+.ticket-table__header--sortable .btn {
+  height: auto;
+  padding: var(--space-sm) var(--space-md);
+}
+
+.ticket-table__sort-icon {
+  margin-left: var(--space-xs);
+}
+
+.ticket-table__row {
+  cursor: pointer;
+}
+
+.ticket-table__row:hover {
+  background: var(--color-pale-green);
+}
+
+.ticket-table__row--skeleton td {
+  background: var(--color-disabled-bg);
+  height: var(--control-height);
+}
+
+.ticket-card-list {
+  display: none;
+}
+
+/* ---------------------------------------------------------------------- */
+/* My Tickets — mobile cards (< 768px)                                    */
+/* ---------------------------------------------------------------------- */
+
+.ticket-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-lg);
+  border: 1px solid var(--color-field-border);
+  border-radius: var(--radius-control);
+  background: var(--color-surface);
+  cursor: pointer;
+}
+
+.ticket-card--skeleton {
+  min-height: 96px;
+  background: var(--color-disabled-bg);
+  cursor: default;
+}
+
+.ticket-card__header-row,
+.ticket-card__secondary-row,
+.ticket-card__footer-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.ticket-card__ticket-number {
+  font-weight: 600;
+}
+
+.ticket-card__title {
+  margin: 0;
+  font-weight: 600;
+  overflow-wrap: break-word;
+}
+
+.ticket-card__footer-row {
+  font-size: var(--font-size-small);
+  color: var(--color-text-muted);
+}
+
+.ticket-card__footer-label {
+  font-weight: 600;
+}
+
+/* ---------------------------------------------------------------------- */
+/* My Tickets — pagination (§13.5, §19)                                   */
+/* ---------------------------------------------------------------------- */
+
+.ticket-list__pagination-summary {
+  font-size: var(--font-size-small);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+}
+
+.pagination__page-btn--active {
+  background: var(--color-primary-green);
+  color: #ffffff;
+  border-radius: var(--radius-control);
+}
+
+/* ---------------------------------------------------------------------- */
+/* My Tickets — responsive breakpoint (ui-spec.md §8, §13.3, §13.4)       */
+/* ---------------------------------------------------------------------- */
+
+@media (max-width: 767px) {
+  .ticket-table {
+    display: none;
+  }
+
+  .ticket-card-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .ticket-toolbar__sort-select {
+    display: inline-flex;
+  }
+}

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import MyTickets from "../../src/screens/MyTickets.js";
+import { RequesterProvider, setSelectedRequester } from "../../src/lib/requesterContext.js";
+
+const baseTicket = {
+  id: 1,
+  ticketNumber: "TKT-2026-000001",
+  requesterId: 1,
+  categoryId: 1,
+  relatedSystemId: 1,
+  summary: "Laptop won't power on",
+  description: "Screen stays black after the firmware update finished overnight.",
+  requestedPriority: "HIGH",
+  status: "NEW",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-02T00:00:00.000Z",
+};
+
+function makeResult(overrides: Record<string, unknown> = {}) {
+  return {
+    data: [baseTicket],
+    page: 1,
+    pageSize: 10,
+    totalCount: 1,
+    totalPages: 1,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as Response;
+}
+
+type TicketsResponder = (url: string) => Response | Promise<Response>;
+
+function setupFetch(
+  options: {
+    categories?: unknown[];
+    ticketsResponder?: TicketsResponder;
+  } = {},
+) {
+  const categories = options.categories ?? [{ id: 1, name: "Hardware" }];
+  const state: { ticketsResponder?: TicketsResponder } = { ticketsResponder: options.ticketsResponder };
+
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    if (url.includes("/api/categories")) return jsonResponse(categories);
+    if (url.includes("/api/tickets")) {
+      if (state.ticketsResponder) return state.ticketsResponder(url);
+      return jsonResponse(makeResult());
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  return {
+    fetchMock,
+    setTicketsResponder: (fn: TicketsResponder) => {
+      state.ticketsResponder = fn;
+    },
+  };
+}
+
+function renderScreen() {
+  setSelectedRequester({ id: 1, name: "Alex Rivera" });
+  return render(
+    <RequesterProvider>
+      <MemoryRouter initialEntries={["/tickets"]}>
+        <Routes>
+          <Route path="/tickets" element={<MyTickets />} />
+          <Route path="/tickets/new" element={<h1>Create Ticket</h1>} />
+          <Route path="/tickets/:id" element={<h1>Ticket Detail</h1>} />
+        </Routes>
+      </MemoryRouter>
+    </RequesterProvider>,
+  );
+}
+
+describe("MyTickets", () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  // UI-18
+  it("shows skeleton rows and cards while the GET is in flight", async () => {
+    let resolveTickets!: (res: Response) => void;
+    const pending = new Promise<Response>((resolve) => {
+      resolveTickets = resolve;
+    });
+    setupFetch({ ticketsResponder: () => pending });
+    renderScreen();
+
+    expect(await screen.findAllByTestId("ticket-skeleton-row")).toHaveLength(3);
+    expect(screen.getAllByTestId("ticket-skeleton-card")).toHaveLength(3);
+
+    resolveTickets(jsonResponse(makeResult()));
+    await waitFor(() => expect(screen.queryAllByTestId("ticket-skeleton-row")).toHaveLength(0));
+  });
+
+  // UI-19
+  it("renders all 7 columns with correctly mapped values", async () => {
+    setupFetch({ ticketsResponder: () => jsonResponse(makeResult()) });
+    renderScreen();
+
+    expect((await screen.findAllByText("TKT-2026-000001")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Laptop won't power on").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Hardware").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("High").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("New").length).toBeGreaterThan(0);
+    const createdDateText = new Date(baseTicket.createdAt).toLocaleDateString();
+    const updatedDateText = new Date(baseTicket.updatedAt).toLocaleDateString();
+    expect(screen.getAllByText(createdDateText).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(updatedDateText).length).toBeGreaterThan(0);
+  });
+
+  // UI-20
+  it("shows the Empty state and hides the toolbar when the Requester owns zero Tickets", async () => {
+    setupFetch({
+      ticketsResponder: () => jsonResponse(makeResult({ data: [], totalCount: 0, totalPages: 0 })),
+    });
+    renderScreen();
+
+    expect(await screen.findByText("No tickets yet")).toBeInTheDocument();
+    expect(screen.getByText("Create your first ticket to get started.")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/Search by ticket number/)).not.toBeInTheDocument();
+  });
+
+  // UI-21
+  it("shows the No-results state and keeps the toolbar visible when a filter matches nothing", async () => {
+    setupFetch({
+      ticketsResponder: (url) =>
+        url.includes("requestedPriority=HIGH")
+          ? jsonResponse(makeResult({ data: [], totalCount: 0, totalPages: 0 }))
+          : jsonResponse(makeResult()),
+    });
+    renderScreen();
+
+    await screen.findAllByText("TKT-2026-000001");
+
+    await userEvent.selectOptions(screen.getByLabelText("Requested Priority"), "HIGH");
+
+    expect(await screen.findByText("No tickets match your search")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Search by ticket number/)).toBeInTheDocument();
+    const clearButtons = screen.getAllByRole("button", { name: "Clear Filters" });
+    expect(clearButtons.length).toBeGreaterThan(0);
+    for (const btn of clearButtons) expect(btn).not.toBeDisabled();
+  });
+
+  // UI-22
+  it("disables Clear Filters with no active filter and enables it once one is applied", async () => {
+    setupFetch({ ticketsResponder: () => jsonResponse(makeResult()) });
+    renderScreen();
+
+    await screen.findAllByText("TKT-2026-000001");
+
+    const clearBtn = screen.getByRole("button", { name: "Clear Filters" });
+    expect(clearBtn).toBeDisabled();
+
+    await userEvent.selectOptions(screen.getByLabelText("Requested Priority"), "HIGH");
+
+    expect(clearBtn).not.toBeDisabled();
+  });
+
+  // UI-23
+  it("toggles sortDir and updates the glyph when clicking the active sortable header", async () => {
+    const { fetchMock } = setupFetch({ ticketsResponder: () => jsonResponse(makeResult()) });
+    renderScreen();
+
+    await screen.findAllByText("TKT-2026-000001");
+
+    const createdDateHeaderBtn = screen.getByRole("button", { name: /Created Date/ });
+    expect(createdDateHeaderBtn.querySelector(".ticket-table__sort-icon")?.textContent).toBe("▼");
+
+    await userEvent.click(createdDateHeaderBtn);
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.map(([url]) => String(url));
+      expect(calls.some((u) => u.includes("/api/tickets") && u.includes("sortDir=asc"))).toBe(true);
+    });
+    expect(createdDateHeaderBtn.querySelector(".ticket-table__sort-icon")?.textContent).toBe("▲");
+  });
+
+  // UI-24
+  it("changing the page-size select updates pageSize and resets to page 1", async () => {
+    const { fetchMock } = setupFetch({
+      ticketsResponder: () => jsonResponse(makeResult({ totalCount: 25, totalPages: 3 })),
+    });
+    renderScreen();
+
+    await screen.findAllByText("TKT-2026-000001");
+
+    await userEvent.click(screen.getByRole("button", { name: "2" }));
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.map(([url]) => String(url));
+      expect(calls.some((u) => u.includes("/api/tickets") && u.includes("page=2"))).toBe(true);
+    });
+
+    await userEvent.selectOptions(screen.getByLabelText("Page Size"), "20");
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.map(([url]) => String(url)).filter((u) => u.includes("/api/tickets"));
+      const last = calls[calls.length - 1] ?? "";
+      expect(last).toContain("pageSize=20");
+      expect(last).toContain("page=1");
+    });
+  });
+
+  // UI-25
+  it("shows a failure banner with a Retry action that re-runs the fetch", async () => {
+    const { setTicketsResponder } = setupFetch({
+      ticketsResponder: () => jsonResponse({ error: "Unexpected server error" }, 500),
+    });
+    renderScreen();
+
+    const banner = await screen.findByText("Couldn't load Tickets.");
+    expect(banner.closest(".state-banner--error")).not.toBeNull();
+
+    setTicketsResponder(() => jsonResponse(makeResult()));
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect((await screen.findAllByText("TKT-2026-000001")).length).toBeGreaterThan(0);
+  });
+});

--- a/client/tests/lab-02/sort-defaults.unit.test.ts
+++ b/client/tests/lab-02/sort-defaults.unit.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { defaultSortDir } from "../../src/lib/sortDefaults.js";
+
+describe("defaultSortDir", () => {
+  // UNIT-09
+  it("returns desc for createdAt", () => {
+    expect(defaultSortDir("createdAt")).toBe("desc");
+  });
+
+  it("returns asc for summary", () => {
+    expect(defaultSortDir("summary")).toBe("asc");
+  });
+
+  it("returns desc for requestedPriority", () => {
+    expect(defaultSortDir("requestedPriority")).toBe("desc");
+  });
+
+  it("returns desc for status", () => {
+    expect(defaultSortDir("status")).toBe("desc");
+  });
+});

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: "./tests/setup.ts",
-    include: ["tests/**/*.test.tsx"],
+    include: ["tests/**/*.test.tsx", "tests/**/*.test.ts"],
   },
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -407,4 +407,148 @@ app.post(
   },
 );
 
+// ---------------------------------------------------------------------------
+// Issue 19 — My Tickets list (api-spec.md §5)
+// ---------------------------------------------------------------------------
+
+const SORTABLE_FIELDS = new Set(["createdAt", "summary", "requestedPriority", "status"]);
+const SORT_DIRS = new Set(["asc", "desc"]);
+const PRIORITIES_FOR_FILTER = new Set(["LOW", "MEDIUM", "HIGH"]);
+const PAGE_SIZES = [10, 20, 50];
+
+function clampPageSize(raw: string | undefined): number {
+  const n = Number(raw);
+  if (!raw || !Number.isFinite(n)) return 10;
+  return PAGE_SIZES.reduce((closest, candidate) =>
+    Math.abs(candidate - n) < Math.abs(closest - n) ? candidate : closest,
+  );
+}
+
+function clampPage(raw: string | undefined): number {
+  const n = Number(raw);
+  if (!raw || !Number.isFinite(n)) return 1;
+  const truncated = Math.trunc(n);
+  return truncated < 1 ? 1 : truncated;
+}
+
+app.get("/api/tickets", async (req: Request, res: Response) => {
+  try {
+    const requesterCheck = await checkRequester(req);
+    if (!requesterCheck.ok) {
+      return res.status(requesterCheck.status).json(requesterCheck.body);
+    }
+    const { requesterId } = requesterCheck;
+
+    const errors: { field: string; message: string }[] = [];
+
+    // categoryId — 400 if not an integer, or an integer that doesn't
+    // reference ANY existing Category row, active or not (api-spec.md §12
+    // OQ-2 — different from POST /api/tickets' active-row check).
+    let categoryId: number | undefined;
+    if (req.query.categoryId !== undefined) {
+      const raw = String(req.query.categoryId);
+      if (!/^\d+$/.test(raw)) {
+        errors.push({ field: "categoryId", message: "categoryId must be an integer" });
+      } else {
+        const id = Number(raw);
+        const category = await getPrisma().category.findUnique({ where: { id } });
+        if (!category) {
+          errors.push({ field: "categoryId", message: "categoryId does not reference a known Category" });
+        } else {
+          categoryId = id;
+        }
+      }
+    }
+
+    let requestedPriority: "LOW" | "MEDIUM" | "HIGH" | undefined;
+    if (req.query.requestedPriority !== undefined) {
+      const raw = String(req.query.requestedPriority);
+      if (!PRIORITIES_FOR_FILTER.has(raw)) {
+        errors.push({ field: "requestedPriority", message: "Requested Priority must be LOW, MEDIUM, or HIGH" });
+      } else {
+        requestedPriority = raw as "LOW" | "MEDIUM" | "HIGH";
+      }
+    }
+
+    let status: "NEW" | undefined;
+    if (req.query.status !== undefined) {
+      const raw = String(req.query.status);
+      if (raw !== "NEW") {
+        errors.push({ field: "status", message: "Status must be NEW" });
+      } else {
+        status = "NEW";
+      }
+    }
+
+    let sortBy: "createdAt" | "summary" | "requestedPriority" | "status" = "createdAt";
+    if (req.query.sortBy !== undefined) {
+      const raw = String(req.query.sortBy);
+      if (!SORTABLE_FIELDS.has(raw)) {
+        errors.push({ field: "sortBy", message: "sortBy must be one of createdAt, summary, requestedPriority, status" });
+      } else {
+        sortBy = raw as typeof sortBy;
+      }
+    }
+
+    let sortDir: "asc" | "desc" = "desc";
+    if (req.query.sortDir !== undefined) {
+      const raw = String(req.query.sortDir);
+      if (!SORT_DIRS.has(raw)) {
+        errors.push({ field: "sortDir", message: "sortDir must be asc or desc" });
+      } else {
+        sortDir = raw as typeof sortDir;
+      }
+    }
+
+    if (errors.length > 0) {
+      return res.status(400).json({ errors });
+    }
+
+    // BR-24, api-spec.md §12 OQ-8 — clamped, never rejected.
+    const page = clampPage(req.query.page !== undefined ? String(req.query.page) : undefined);
+    const pageSize = clampPageSize(req.query.pageSize !== undefined ? String(req.query.pageSize) : undefined);
+
+    const search = req.query.search !== undefined ? String(req.query.search) : undefined;
+
+    const where: Prisma.TicketWhereInput = { requesterId };
+    if (categoryId !== undefined) where.categoryId = categoryId;
+    if (requestedPriority !== undefined) where.requestedPriority = requestedPriority;
+    if (status !== undefined) where.status = status;
+    if (search) {
+      where.OR = [
+        { ticketNumber: { startsWith: search } },
+        { summary: { contains: search, mode: "insensitive" } },
+      ];
+    }
+
+    // api-spec.md §12 OQ-7 — id-descending tiebreaker on every sort, not
+    // only the default.
+    const orderBy: Prisma.TicketOrderByWithRelationInput[] = [
+      { [sortBy]: sortDir },
+      { id: "desc" },
+    ];
+
+    const [totalCount, tickets] = await Promise.all([
+      getPrisma().ticket.count({ where }),
+      getPrisma().ticket.findMany({
+        where,
+        orderBy,
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+    ]);
+
+    return res.status(200).json({
+      data: tickets.map(ticketToJSON),
+      page,
+      pageSize,
+      totalCount,
+      totalPages: Math.ceil(totalCount / pageSize),
+    });
+  } catch (err) {
+    console.error("GET /api/tickets failed:", err);
+    res.status(500).json({ error: "Unexpected server error" });
+  }
+});
+
 export default app;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -419,6 +419,12 @@ const PAGE_SIZES = [10, 20, 50];
 function clampPageSize(raw: string | undefined): number {
   const n = Number(raw);
   if (!raw || !Number.isFinite(n)) return 10;
+  // On an exact tie (e.g. 15, equidistant from 10 and 20), reduce keeps
+  // whichever candidate it reaches first, which is the smaller one since
+  // PAGE_SIZES is ascending. Rounding down on a tie has no basis in
+  // api-spec.md §12 OQ-8 beyond "nearest allowed value" — it's simply this
+  // implementation's tie-break, made explicit here rather than left implicit
+  // in reduce's iteration order.
   return PAGE_SIZES.reduce((closest, candidate) =>
     Math.abs(candidate - n) < Math.abs(closest - n) ? candidate : closest,
   );

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -1,0 +1,396 @@
+import "./testDbEnv.js";
+
+import { randomUUID } from "node:crypto";
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverRoot = path.join(__dirname, "..", "..");
+
+const { app } = await import("../../src/app.js");
+const { getPrisma } = await import("../../src/prisma.js");
+
+async function truncateAll() {
+  await getPrisma().$executeRawUnsafe(
+    `TRUNCATE TABLE "Attachment", "Ticket", "RequesterUser", "RelatedSystem", "Category" RESTART IDENTITY CASCADE;`,
+  );
+}
+
+async function seedCategory(name: string, isActive = true) {
+  return getPrisma().category.create({ data: { name, isActive } });
+}
+
+async function seedRelatedSystem(name: string, isActive = true) {
+  return getPrisma().relatedSystem.create({ data: { name, isActive } });
+}
+
+async function seedRequester(name: string, email: string, isActive = true) {
+  return getPrisma().requesterUser.create({ data: { name, email, isActive } });
+}
+
+let ticketCounter = 1;
+async function seedTicket(params: {
+  requesterId: number;
+  categoryId: number;
+  relatedSystemId: number;
+  summary?: string;
+  requestedPriority?: "LOW" | "MEDIUM" | "HIGH";
+  createdAt?: Date;
+}) {
+  const n = ticketCounter++;
+  return getPrisma().ticket.create({
+    data: {
+      ticketNumber: `TKT-2026-${String(n).padStart(6, "0")}`,
+      requesterId: params.requesterId,
+      categoryId: params.categoryId,
+      relatedSystemId: params.relatedSystemId,
+      summary: params.summary ?? `Ticket summary ${n}`,
+      description: "Default description long enough for validation purposes.",
+      requestedPriority: params.requestedPriority ?? "MEDIUM",
+      status: "NEW",
+      idempotencyKey: randomUUID(),
+      createdAt: params.createdAt,
+    },
+  });
+}
+
+describe("My Tickets", () => {
+  beforeAll(() => {
+    execSync("npx prisma migrate deploy --schema=prisma/schema.prisma", {
+      cwd: serverRoot,
+      stdio: "inherit",
+      env: process.env,
+    });
+  });
+
+  beforeEach(async () => {
+    ticketCounter = 1;
+    await truncateAll();
+  });
+
+  afterAll(async () => {
+    await getPrisma().$disconnect();
+    // Prevents this override from leaking into a lab-01 test file that
+    // might share this worker's process.env afterward.
+    delete process.env.DATABASE_URL;
+  });
+
+  // API-16
+  it("GET /api/tickets without X-Requester-Id returns 400", async () => {
+    const res = await request(app).get("/api/tickets");
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual([
+      { field: "X-Requester-Id", message: "Missing or invalid requester header" },
+    ]);
+  });
+
+  // API-17
+  it("scopes results to the calling Requester only", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const alex = await seedRequester("Alex Rivera", "alex@example.com");
+    const sam = await seedRequester("Sam Okafor", "sam@example.com");
+    await seedTicket({ requesterId: alex.id, categoryId: category.id, relatedSystemId: relatedSystem.id });
+    await seedTicket({ requesterId: sam.id, categoryId: category.id, relatedSystemId: relatedSystem.id });
+
+    const alexRes = await request(app).get("/api/tickets").set("X-Requester-Id", String(alex.id));
+    const samRes = await request(app).get("/api/tickets").set("X-Requester-Id", String(sam.id));
+
+    expect(alexRes.body.data).toHaveLength(1);
+    expect(alexRes.body.data[0].requesterId).toBe(alex.id);
+    expect(samRes.body.data).toHaveLength(1);
+    expect(samRes.body.data[0].requesterId).toBe(sam.id);
+  });
+
+  // API-18
+  it("returns page 1 of 10 by default for a 25-Ticket Requester", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const base = new Date("2026-01-01T00:00:00.000Z");
+    for (let i = 0; i < 25; i++) {
+      await seedTicket({
+        requesterId: requester.id,
+        categoryId: category.id,
+        relatedSystemId: relatedSystem.id,
+        createdAt: new Date(base.getTime() + i * 1000),
+      });
+    }
+
+    const res = await request(app).get("/api/tickets").set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(10);
+    expect(res.body.page).toBe(1);
+    expect(res.body.pageSize).toBe(10);
+    expect(res.body.totalCount).toBe(25);
+    expect(res.body.totalPages).toBe(3);
+  });
+
+  // API-19
+  it("returns the correct slice for page=2 and page=3", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const base = new Date("2026-01-01T00:00:00.000Z");
+    for (let i = 0; i < 25; i++) {
+      await seedTicket({
+        requesterId: requester.id,
+        categoryId: category.id,
+        relatedSystemId: relatedSystem.id,
+        createdAt: new Date(base.getTime() + i * 1000),
+      });
+    }
+
+    const page2 = await request(app).get("/api/tickets?page=2").set("X-Requester-Id", String(requester.id));
+    const page3 = await request(app).get("/api/tickets?page=3").set("X-Requester-Id", String(requester.id));
+
+    expect(page2.body.data).toHaveLength(10);
+    expect(page3.body.data).toHaveLength(5);
+  });
+
+  // API-20
+  it("returns an empty data array, not an error, for a page beyond the last", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    await seedTicket({ requesterId: requester.id, categoryId: category.id, relatedSystemId: relatedSystem.id });
+
+    const res = await request(app).get("/api/tickets?page=99").set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  // API-21
+  it("clamps pageSize=999 to 50", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    await seedTicket({ requesterId: requester.id, categoryId: category.id, relatedSystemId: relatedSystem.id });
+
+    const res = await request(app).get("/api/tickets?pageSize=999").set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.pageSize).toBe(50);
+  });
+
+  // API-22
+  it("clamps page=0 to 1", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    await seedTicket({ requesterId: requester.id, categoryId: category.id, relatedSystemId: relatedSystem.id });
+
+    const res = await request(app).get("/api/tickets?page=0").set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.page).toBe(1);
+  });
+
+  // API-23
+  it("search matches Ticket Number by prefix", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({ requesterId: requester.id, categoryId: category.id, relatedSystemId: relatedSystem.id });
+    await seedTicket({ requesterId: requester.id, categoryId: category.id, relatedSystemId: relatedSystem.id });
+
+    const res = await request(app)
+      .get(`/api/tickets?search=${ticket.ticketNumber}`)
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].ticketNumber).toBe(ticket.ticketNumber);
+  });
+
+  // API-24
+  it("search matches Summary by case-insensitive substring", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+      summary: "Laptop won't power on",
+    });
+    await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+      summary: "Printer jam on floor 3",
+    });
+
+    const res = await request(app).get("/api/tickets?search=POWER").set("X-Requester-Id", String(requester.id));
+
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].summary).toBe("Laptop won't power on");
+  });
+
+  // API-25
+  it("filters by categoryId", async () => {
+    const hardware = await seedCategory("Hardware");
+    const software = await seedCategory("Software");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    await seedTicket({ requesterId: requester.id, categoryId: hardware.id, relatedSystemId: relatedSystem.id });
+    await seedTicket({ requesterId: requester.id, categoryId: software.id, relatedSystemId: relatedSystem.id });
+
+    const res = await request(app)
+      .get(`/api/tickets?categoryId=${hardware.id}`)
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].categoryId).toBe(hardware.id);
+  });
+
+  // API-26
+  it("filters by requestedPriority=HIGH", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+      requestedPriority: "HIGH",
+    });
+    await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+      requestedPriority: "LOW",
+    });
+
+    const res = await request(app)
+      .get("/api/tickets?requestedPriority=HIGH")
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].requestedPriority).toBe("HIGH");
+  });
+
+  // API-27
+  it("returns 400 for a categoryId that references no Category row", async () => {
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app).get("/api/tickets?categoryId=999").set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: "categoryId" })]),
+    );
+  });
+
+  // API-28
+  it("returns 400 for invalid sortBy, invalid sortDir, and status=RESOLVED", async () => {
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const badSortBy = await request(app)
+      .get("/api/tickets?sortBy=notAField")
+      .set("X-Requester-Id", String(requester.id));
+    const badSortDir = await request(app)
+      .get("/api/tickets?sortDir=sideways")
+      .set("X-Requester-Id", String(requester.id));
+    const badStatus = await request(app)
+      .get("/api/tickets?status=RESOLVED")
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(badSortBy.status).toBe(400);
+    expect(badSortBy.body.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: "sortBy" })]),
+    );
+    expect(badSortDir.status).toBe(400);
+    expect(badSortDir.body.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: "sortDir" })]),
+    );
+    expect(badStatus.status).toBe(400);
+    expect(badStatus.body.errors).toEqual([{ field: "status", message: "Status must be NEW" }]);
+  });
+
+  // API-29
+  it("sorts by requestedPriority descending (HIGH-first) and ascending (LOW-first)", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    await seedTicket({ requesterId: requester.id, categoryId: category.id, relatedSystemId: relatedSystem.id, requestedPriority: "LOW" });
+    await seedTicket({ requesterId: requester.id, categoryId: category.id, relatedSystemId: relatedSystem.id, requestedPriority: "HIGH" });
+    await seedTicket({ requesterId: requester.id, categoryId: category.id, relatedSystemId: relatedSystem.id, requestedPriority: "MEDIUM" });
+
+    const desc = await request(app)
+      .get("/api/tickets?sortBy=requestedPriority&sortDir=desc")
+      .set("X-Requester-Id", String(requester.id));
+    const asc = await request(app)
+      .get("/api/tickets?sortBy=requestedPriority&sortDir=asc")
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(desc.body.data.map((t: { requestedPriority: string }) => t.requestedPriority)).toEqual([
+      "HIGH",
+      "MEDIUM",
+      "LOW",
+    ]);
+    expect(asc.body.data.map((t: { requestedPriority: string }) => t.requestedPriority)).toEqual([
+      "LOW",
+      "MEDIUM",
+      "HIGH",
+    ]);
+  });
+
+  // API-30
+  it("tiebreaks equal createdAt values by id descending, deterministically", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const sameCreatedAt = new Date("2026-01-01T00:00:00.000Z");
+    const first = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+      createdAt: sameCreatedAt,
+    });
+    const second = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+      createdAt: sameCreatedAt,
+    });
+
+    const res1 = await request(app).get("/api/tickets").set("X-Requester-Id", String(requester.id));
+    const res2 = await request(app).get("/api/tickets").set("X-Requester-Id", String(requester.id));
+
+    expect(res1.body.data.map((t: { id: number }) => t.id)).toEqual([second.id, first.id]);
+    expect(res2.body.data.map((t: { id: number }) => t.id)).toEqual([second.id, first.id]);
+  });
+
+  // API-31
+  it("returns data: [] and totalCount: 0 for a Requester with zero Tickets", async () => {
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app).get("/api/tickets").set("X-Requester-Id", String(requester.id));
+
+    expect(res.body.data).toEqual([]);
+    expect(res.body.totalCount).toBe(0);
+  });
+
+  // API-32
+  it("returns an empty filtered list while an unfiltered request for the same Requester is non-empty", async () => {
+    const hardware = await seedCategory("Hardware");
+    const software = await seedCategory("Software");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    await seedTicket({ requesterId: requester.id, categoryId: hardware.id, relatedSystemId: relatedSystem.id });
+
+    const unfiltered = await request(app).get("/api/tickets").set("X-Requester-Id", String(requester.id));
+    const filtered = await request(app)
+      .get(`/api/tickets?categoryId=${software.id}`)
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(unfiltered.body.data.length).toBeGreaterThan(0);
+    expect(filtered.body.data).toEqual([]);
+  });
+});

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,5 +4,9 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    // Multiple lab-02 API test files share the toktickit_test database and
+    // truncate it in their own beforeEach; running files in parallel races
+    // one file's truncation against another's in-flight seed/assertions.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
Closes #19

## What this adds

- `GET /api/tickets` — search (prefix on ticket number, substring on
  summary), category/priority/status filters, sort with a universal
  id-descending tiebreaker (api-spec.md §12 OQ-7), clamped pagination
  (OQ-8)
- `MyTickets` screen: toolbar, sortable desktop table, mobile card view,
  a mobile Sort-by select, pagination
- `Pagination`, reused `Badge` for priority/status
- Mounted at `/tickets`, replacing the placeholder

## One defect fixed before commit

The page number didn't reset when a filter or search value changed —
only Clear Filters and the page-size select reset it. Sitting on page 2
of a filtered view, then loosening the filter, left `page` at 2. With
fewer total results, page 2 could return an empty `data` array even
though tickets existed on page 1, which would misrender as the
zero-tickets "No tickets yet" panel. Fixed: `page` now resets to 1
whenever `search`/`categoryId`/`requestedPriority`/`status` changes.

## Two things worth a close look

1. `categoryId` on this endpoint 400s only when the id references no
   Category row at all (active or not) — deliberately different from
   `POST /api/tickets`'s active-row check (api-spec.md §12 OQ-2). A
   filter against a deactivated Category is valid and returns whatever
   still matches.
2. Empty vs. no-results is decided from a single fetch, not two: if the
   result is empty and no filter is currently applied, it's Empty; if a
   filter is applied, it's No-results. This matches `ui-spec.md` §7's
   instruction not to fire a second request just to distinguish them.

## Verified locally

- `npx tsc --noEmit` — clean
- `npm run build` — succeeds
- Server tests: `my-tickets.api.test.ts`, 17 cases (API-16–32) — pass
- Client tests: `MyTickets.test.tsx` (UI-18–25),
  `sort-defaults.unit.test.ts` (UNIT-09) — pass, fetch mocked
- No `.js` files emitted under `client/src` or `client/tests`
