### PR TITLE
feat(lab-02): Ticket Detail

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import AppShell from "./components/AppShell.js";
 import RequesterSelect from "./screens/RequesterSelect.js";
 import CreateTicketForm from "./screens/CreateTicketForm.js";
 import MyTickets from "./screens/MyTickets.js";
+import TicketDetail from "./screens/TicketDetail.js";
 import { RequesterProvider, useRequester } from "./lib/requesterContext.js";
 
 // AC-02: /tickets, /tickets/new, /tickets/:id redirect here when nothing is
@@ -14,10 +15,6 @@ function RequireRequester({ children }: { children: ReactNode }) {
     return <Navigate to="/select-requester" replace />;
   }
   return <>{children}</>;
-}
-
-function TicketDetailPlaceholder() {
-  return <h1>Ticket Detail</h1>;
 }
 
 function NotFoundPlaceholder() {
@@ -56,7 +53,7 @@ export default function App() {
             element={
               <RequireRequester>
                 <AppShell>
-                  <TicketDetailPlaceholder />
+                  <TicketDetail />
                 </AppShell>
               </RequireRequester>
             }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -186,3 +186,24 @@ export async function uploadAttachments(ticketId: number, files: File[]): Promis
   }
   return (await res.json()) as Attachment[];
 }
+
+// api-spec.md §0.3, §6 — the Ticket representation plus its Attachments.
+export interface TicketDetail extends Ticket {
+  attachments: Attachment[];
+}
+
+// Issue 20 — thrown by getTicket on a 404, so the screen can render the
+// not-found panel specifically rather than the generic failure banner
+// (BR-10, BR-36: missing vs. cross-Requester are indistinguishable).
+export class NotFoundError extends Error {}
+
+export async function getTicket(id: number): Promise<TicketDetail> {
+  const res = await apiFetch(`/api/tickets/${id}`);
+  if (res.status === 404) {
+    throw new NotFoundError("Not found");
+  }
+  if (!res.ok) {
+    throw new Error(`Ticket fetch failed with status ${res.status}`);
+  }
+  return (await res.json()) as TicketDetail;
+}

--- a/client/src/screens/TicketDetail.tsx
+++ b/client/src/screens/TicketDetail.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  getCategories,
+  getRelatedSystems,
+  getTicket,
+  NotFoundError,
+  type Attachment,
+  type Category,
+  type RelatedSystem,
+  type TicketDetail as TicketDetailData,
+} from "../api.js";
+import Badge from "../components/Badge.js";
+import StateBanner from "../components/StateBanner.js";
+
+type LoadState = "loading" | "loaded" | "not-found" | "error";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString();
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function TextField({
+  label,
+  value,
+  fullWidth,
+  wrap,
+}: {
+  label: string;
+  value: string;
+  fullWidth?: boolean;
+  wrap?: boolean;
+}) {
+  return (
+    <div className="field" style={fullWidth ? { gridColumn: "1 / -1" } : undefined}>
+      <span className="field__label">{label}</span>
+      <div
+        className="field__control field__control--readonly"
+        style={wrap ? { height: "auto", whiteSpace: "pre-wrap" } : undefined}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function BadgeField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="field">
+      <span className="field__label">{label}</span>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function AttachmentRow({ attachment }: { attachment: Attachment }) {
+  return (
+    <li
+      className={`attachment-item ${attachment.isRemoved ? "attachment-item--removed" : "attachment-item--active"}`}
+    >
+      <span className="attachment-item__name">{attachment.originalFilename}</span>
+      <span className="attachment-item__meta">
+        {formatSize(attachment.sizeBytes)} · Uploaded {formatDate(attachment.createdAt)}
+        {attachment.isRemoved && attachment.removedAt && (
+          <>
+            {" "}
+            · Removed {formatDate(attachment.removedAt)}
+            {attachment.removalReason ? ` — ${attachment.removalReason}` : ""}
+          </>
+        )}
+      </span>
+    </li>
+  );
+}
+
+export default function TicketDetail() {
+  const { id } = useParams<{ id: string }>();
+
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [relatedSystems, setRelatedSystems] = useState<RelatedSystem[]>([]);
+
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+  const [ticket, setTicket] = useState<TicketDetailData | null>(null);
+
+  useEffect(() => {
+    getCategories()
+      .then(setCategories)
+      .catch(() => {});
+    getRelatedSystems()
+      .then(setRelatedSystems)
+      .catch(() => {});
+  }, []);
+
+  const load = useCallback(() => {
+    setLoadState("loading");
+    getTicket(Number(id))
+      .then((t) => {
+        setTicket(t);
+        setLoadState("loaded");
+      })
+      .catch((err) => {
+        setLoadState(err instanceof NotFoundError ? "not-found" : "error");
+      });
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  function categoryName(categoryId: number): string {
+    return categories.find((c) => c.id === categoryId)?.name ?? String(categoryId);
+  }
+
+  function relatedSystemName(relatedSystemId: number): string {
+    return relatedSystems.find((r) => r.id === relatedSystemId)?.name ?? String(relatedSystemId);
+  }
+
+  // BR-10/BR-36: worded identically whether the Ticket doesn't exist or
+  // belongs to someone else — there is nothing to detect, so nothing to
+  // branch on here.
+  if (loadState === "not-found") {
+    return (
+      <div className="ticket-detail">
+        <StateBanner variant="error">
+          <h2>Ticket not found</h2>
+          <p>This ticket doesn't exist, or isn't available to you.</p>
+          <Link to="/tickets" className="btn btn--secondary">
+            Back to My Tickets
+          </Link>
+        </StateBanner>
+      </div>
+    );
+  }
+
+  const activeCount = ticket ? ticket.attachments.filter((a) => !a.isRemoved).length : 0;
+
+  return (
+    <div className="ticket-detail">
+      <Link to="/tickets" className="btn btn--tertiary ticket-detail__back-link">
+        ← Back to My Tickets
+      </Link>
+
+      {loadState === "error" && (
+        <StateBanner variant="error">
+          <p>Couldn't load Ticket.</p>
+          <button type="button" className="btn btn--secondary" onClick={load}>
+            Retry
+          </button>
+        </StateBanner>
+      )}
+
+      {loadState === "loading" && (
+        <>
+          <section className="ticket-detail__header" data-testid="ticket-detail-header-skeleton">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="field__control field__control--disabled" aria-hidden="true" />
+            ))}
+          </section>
+          <section className="ticket-detail__attachments" data-testid="ticket-detail-attachments-skeleton">
+            <div className="field__control field__control--disabled" aria-hidden="true" />
+          </section>
+        </>
+      )}
+
+      {loadState === "loaded" && ticket && (
+        <>
+          <section className="ticket-detail__header">
+            <TextField label="Ticket Number" value={ticket.ticketNumber} />
+            <TextField label="Created Date" value={formatDate(ticket.createdAt)} />
+            <TextField label="Category" value={categoryName(ticket.categoryId)} />
+            <TextField label="Related System" value={relatedSystemName(ticket.relatedSystemId)} />
+            <BadgeField label="Requested Priority">
+              <Badge kind="priority" value={ticket.requestedPriority} />
+            </BadgeField>
+            <BadgeField label="Current Status">
+              <Badge kind="status" value={ticket.status} />
+            </BadgeField>
+            <TextField label="Summary" value={ticket.summary} fullWidth />
+            <TextField label="Description" value={ticket.description} fullWidth wrap />
+          </section>
+
+          <section className="ticket-detail__attachments">
+            <h2>Attachments ({activeCount} active)</h2>
+            {ticket.attachments.length === 0 ? (
+              <p>No attachments</p>
+            ) : (
+              <ul className="attachment-list">
+                {ticket.attachments.map((a) => (
+                  <AttachmentRow key={a.id} attachment={a} />
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/styles/components.css
+++ b/client/src/styles/components.css
@@ -663,3 +663,75 @@ textarea.field__control {
     display: inline-flex;
   }
 }
+
+/* ---------------------------------------------------------------------- */
+/* Ticket Detail — ui-spec.md §16, §17, §19                               */
+/* ---------------------------------------------------------------------- */
+
+.ticket-detail {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.ticket-detail__back-link {
+  align-self: flex-start;
+}
+
+.ticket-detail__header {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--space-lg);
+  padding: var(--space-xl);
+  background: var(--color-surface);
+  border-radius: var(--radius-control);
+}
+
+.ticket-detail__attachments {
+  padding: var(--space-xl);
+  background: var(--color-surface);
+  border-radius: var(--radius-control);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.attachment-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.attachment-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--color-field-border);
+  border-radius: var(--radius-control);
+  background: var(--color-surface);
+}
+
+.attachment-item--active {
+  opacity: 1;
+}
+
+.attachment-item--removed {
+  opacity: 0.6;
+}
+
+.attachment-item__name {
+  font-weight: 600;
+}
+
+.attachment-item__meta {
+  font-size: var(--font-size-small);
+  color: var(--color-text-muted);
+}

--- a/client/tests/lab-02/TicketDetail.test.tsx
+++ b/client/tests/lab-02/TicketDetail.test.tsx
@@ -1,0 +1,129 @@
+// UI-28/29/30/32 (Remove confirmation, removed-row control absence, 404
+// preview/download, and Preview-opens-new-tab) are not written here — they
+// exercise the attachment Preview/Download/Remove endpoints from Issue #21,
+// which don't exist yet. Only UI-26, UI-27, and UI-31 are covered.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import TicketDetail from "../../src/screens/TicketDetail.js";
+import { RequesterProvider, setSelectedRequester } from "../../src/lib/requesterContext.js";
+
+const baseTicket = {
+  id: 42,
+  ticketNumber: "TKT-2026-000042",
+  requesterId: 1,
+  categoryId: 1,
+  relatedSystemId: 1,
+  summary: "Laptop won't power on after firmware update",
+  description: "Laptop screen stays black after the scheduled firmware update finished overnight.",
+  requestedPriority: "HIGH",
+  status: "NEW",
+  createdAt: "2026-08-29T10:15:00.000Z",
+  updatedAt: "2026-08-29T10:15:00.000Z",
+  attachments: [
+    {
+      id: 101,
+      ticketId: 42,
+      originalFilename: "screenshot.png",
+      mimeType: "image/png",
+      sizeBytes: 245678,
+      createdAt: "2026-08-29T10:16:00.000Z",
+      isRemoved: false,
+      removedAt: null,
+      removalReason: null,
+    },
+  ],
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as Response;
+}
+
+type TicketResponder = () => Response | Promise<Response>;
+
+function setupFetch(options: { categories?: unknown[]; relatedSystems?: unknown[]; ticketResponder: TicketResponder }) {
+  const categories = options.categories ?? [{ id: 1, name: "Hardware" }];
+  const relatedSystems = options.relatedSystems ?? [{ id: 1, name: "Email" }];
+
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    if (url.includes("/api/categories")) return jsonResponse(categories);
+    if (url.includes("/api/related-systems")) return jsonResponse(relatedSystems);
+    if (url.match(/\/api\/tickets\/\d+$/)) return options.ticketResponder();
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  return { fetchMock };
+}
+
+function renderScreen(ticketId = "42") {
+  setSelectedRequester({ id: 1, name: "Alex Rivera" });
+  return render(
+    <RequesterProvider>
+      <MemoryRouter initialEntries={[`/tickets/${ticketId}`]}>
+        <Routes>
+          <Route path="/tickets" element={<h1>My Tickets</h1>} />
+          <Route path="/tickets/:id" element={<TicketDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </RequesterProvider>,
+  );
+}
+
+describe("TicketDetail", () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  // UI-31
+  it("shows a skeleton placeholder for both panels while the GET is in flight", async () => {
+    let resolveTicket!: (res: Response) => void;
+    const pending = new Promise<Response>((resolve) => {
+      resolveTicket = resolve;
+    });
+    setupFetch({ ticketResponder: () => pending });
+    renderScreen();
+
+    expect(screen.getByTestId("ticket-detail-header-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("ticket-detail-attachments-skeleton")).toBeInTheDocument();
+
+    resolveTicket(jsonResponse(baseTicket));
+    await waitFor(() => expect(screen.queryByTestId("ticket-detail-header-skeleton")).not.toBeInTheDocument());
+  });
+
+  // UI-26
+  it("renders the read-only header fields and Attachments panel with badges, once loaded", async () => {
+    setupFetch({ ticketResponder: () => jsonResponse(baseTicket) });
+    renderScreen();
+
+    expect(await screen.findByText("TKT-2026-000042")).toBeInTheDocument();
+    expect(screen.getByText("Laptop won't power on after firmware update")).toBeInTheDocument();
+    expect(
+      screen.getByText("Laptop screen stays black after the scheduled firmware update finished overnight."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Hardware")).toBeInTheDocument();
+    expect(screen.getByText("Email")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(screen.getByText("New")).toBeInTheDocument();
+
+    expect(screen.getByText("Attachments (1 active)")).toBeInTheDocument();
+    expect(screen.getByText("screenshot.png")).toBeInTheDocument();
+  });
+
+  // UI-27
+  it("renders an identically-worded not-found panel whether the Ticket is missing or owned by someone else", async () => {
+    setupFetch({ ticketResponder: () => jsonResponse({ error: "Not found" }, 404) });
+    renderScreen();
+
+    expect(await screen.findByText("Ticket not found")).toBeInTheDocument();
+    expect(
+      screen.getByText("This ticket doesn't exist, or isn't available to you."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to My Tickets" })).toBeInTheDocument();
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -557,4 +557,42 @@ app.get("/api/tickets", async (req: Request, res: Response) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// Issue 20 — Ticket Detail (api-spec.md §6)
+// ---------------------------------------------------------------------------
+app.get("/api/tickets/:id", async (req: Request, res: Response) => {
+  try {
+    const requesterCheck = await checkRequester(req);
+    if (!requesterCheck.ok) {
+      return res.status(requesterCheck.status).json(requesterCheck.body);
+    }
+    const { requesterId } = requesterCheck;
+
+    // Not an integer id — treated as not-found, not a 400 (api-spec.md §6,
+    // this endpoint defines no 400 case).
+    if (!/^\d+$/.test(req.params.id)) {
+      return res.status(404).json({ error: "Not found" });
+    }
+    const ticketId = Number(req.params.id);
+
+    const ticket = await getPrisma().ticket.findUnique({ where: { id: ticketId } });
+    if (!ticket || ticket.requesterId !== requesterId) {
+      return res.status(404).json({ error: "Not found" });
+    }
+
+    const attachments = await getPrisma().attachment.findMany({
+      where: { ticketId },
+      orderBy: { id: "asc" },
+    });
+
+    return res.status(200).json({
+      ...ticketToJSON(ticket),
+      attachments: attachments.map(attachmentToJSON),
+    });
+  } catch (err) {
+    console.error(`GET /api/tickets/${req.params.id} failed:`, err);
+    res.status(500).json({ error: "Unexpected server error" });
+  }
+});
+
 export default app;

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -1,0 +1,213 @@
+import "./testDbEnv.js";
+
+import { randomUUID } from "node:crypto";
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverRoot = path.join(__dirname, "..", "..");
+
+const { app } = await import("../../src/app.js");
+const { getPrisma } = await import("../../src/prisma.js");
+
+async function truncateAll() {
+  await getPrisma().$executeRawUnsafe(
+    `TRUNCATE TABLE "Attachment", "Ticket", "RequesterUser", "RelatedSystem", "Category" RESTART IDENTITY CASCADE;`,
+  );
+}
+
+async function seedCategory(name: string, isActive = true) {
+  return getPrisma().category.create({ data: { name, isActive } });
+}
+
+async function seedRelatedSystem(name: string, isActive = true) {
+  return getPrisma().relatedSystem.create({ data: { name, isActive } });
+}
+
+async function seedRequester(name: string, email: string, isActive = true) {
+  return getPrisma().requesterUser.create({ data: { name, email, isActive } });
+}
+
+async function seedTicket(params: {
+  requesterId: number;
+  categoryId: number;
+  relatedSystemId: number;
+}) {
+  return getPrisma().ticket.create({
+    data: {
+      ticketNumber: `TKT-2026-${String(Math.floor(Math.random() * 1_000_000)).padStart(6, "0")}`,
+      requesterId: params.requesterId,
+      categoryId: params.categoryId,
+      relatedSystemId: params.relatedSystemId,
+      summary: "Laptop won't power on after firmware update",
+      description: "Default description long enough for validation purposes.",
+      requestedPriority: "HIGH",
+      status: "NEW",
+      idempotencyKey: randomUUID(),
+    },
+  });
+}
+
+async function seedAttachment(params: {
+  ticketId: number;
+  originalFilename?: string;
+  removedAt?: Date;
+  removalReason?: string;
+}) {
+  return getPrisma().attachment.create({
+    data: {
+      ticketId: params.ticketId,
+      originalFilename: params.originalFilename ?? "screenshot.png",
+      storedFilename: randomUUID(),
+      mimeType: "image/png",
+      sizeBytes: 245678,
+      removedAt: params.removedAt,
+      removalReason: params.removalReason,
+    },
+  });
+}
+
+describe("Ticket Detail", () => {
+  beforeAll(() => {
+    execSync("npx prisma migrate deploy --schema=prisma/schema.prisma", {
+      cwd: serverRoot,
+      stdio: "inherit",
+      env: process.env,
+    });
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  afterAll(async () => {
+    await getPrisma().$disconnect();
+    delete process.env.DATABASE_URL;
+  });
+
+  // API-33
+  it("GET /api/tickets/:id owned returns 200 with the Ticket representation plus attachments", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const removed = await seedAttachment({
+      ticketId: ticket.id,
+      originalFilename: "old-screenshot.png",
+      removedAt: new Date("2026-08-29T11:30:00.000Z"),
+      removalReason: "Duplicate",
+    });
+    const active = await seedAttachment({ ticketId: ticket.id, originalFilename: "screenshot.png" });
+
+    const res = await request(app).get(`/api/tickets/${ticket.id}`).set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(ticket.id);
+    expect(res.body.ticketNumber).toBe(ticket.ticketNumber);
+    expect(res.body.requesterId).toBe(requester.id);
+
+    // Ordered by id ascending, removed attachments included with isRemoved: true.
+    expect(res.body.attachments).toHaveLength(2);
+    expect(res.body.attachments[0]).toMatchObject({
+      id: removed.id,
+      originalFilename: "old-screenshot.png",
+      isRemoved: true,
+      removedAt: "2026-08-29T11:30:00.000Z",
+      removalReason: "Duplicate",
+    });
+    expect(res.body.attachments[1]).toMatchObject({
+      id: active.id,
+      originalFilename: "screenshot.png",
+      isRemoved: false,
+      removedAt: null,
+      removalReason: null,
+    });
+  });
+
+  it("GET /api/tickets/:id owned with no attachments returns an empty attachments array", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+
+    const res = await request(app).get(`/api/tickets/${ticket.id}`).set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.attachments).toEqual([]);
+  });
+
+  // API-34
+  it("GET /api/tickets/:id owned by a different Requester returns 404", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const owner = await seedRequester("Alex Rivera", "alex@example.com");
+    const other = await seedRequester("Sam Okafor", "sam@example.com");
+    const ticket = await seedTicket({
+      requesterId: owner.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+
+    const res = await request(app).get(`/api/tickets/${ticket.id}`).set("X-Requester-Id", String(other.id));
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Not found" });
+  });
+
+  // API-35
+  it("GET /api/tickets/:id for a nonexistent id returns a body byte-identical to the cross-Requester 404", async () => {
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const crossRequesterRes = await request(app)
+      .get("/api/tickets/999999")
+      .set("X-Requester-Id", String(requester.id));
+
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const owner = await seedRequester("Sam Okafor", "sam@example.com");
+    const ticket = await seedTicket({
+      requesterId: owner.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const notOwnedRes = await request(app)
+      .get(`/api/tickets/${ticket.id}`)
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(crossRequesterRes.status).toBe(404);
+    expect(notOwnedRes.status).toBe(404);
+    expect(JSON.stringify(crossRequesterRes.body)).toBe(JSON.stringify(notOwnedRes.body));
+    expect(crossRequesterRes.body).toEqual({ error: "Not found" });
+  });
+
+  // API-36
+  it("GET /api/tickets/:id without X-Requester-Id returns 400", async () => {
+    const res = await request(app).get("/api/tickets/1");
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual([
+      { field: "X-Requester-Id", message: "Missing or invalid requester header" },
+    ]);
+  });
+
+  // API-37
+  it("GET /api/tickets/:id with a header that is not an active Requester returns 403", async () => {
+    const inactive = await seedRequester("Inactive Person", "inactive@example.com", false);
+
+    const res = await request(app).get("/api/tickets/1").set("X-Requester-Id", String(inactive.id));
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Selected Requester is not active" });
+  });
+});

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -191,6 +191,15 @@ describe("Ticket Detail", () => {
     expect(crossRequesterRes.body).toEqual({ error: "Not found" });
   });
 
+  it("GET /api/tickets/abc (non-numeric id) returns 404 with the same body as the other not-found cases", async () => {
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app).get("/api/tickets/abc").set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Not found" });
+  });
+
   // API-36
   it("GET /api/tickets/:id without X-Requester-Id returns 400", async () => {
     const res = await request(app).get("/api/tickets/1");


### PR DESCRIPTION
Closes #20

## What this adds

- `GET /api/tickets/:id` — Ticket plus its full `attachments[]` array,
  ownership-scoped, 404 for both missing and cross-Requester access
  (BR-10, BR-36)
- `TicketDetail` screen: read-only header panel, attachments panel,
  loading skeleton, not-found panel, generic failure banner with Retry
- Mounted at `/tickets/:id`, replacing the placeholder

## Scope note: attachment actions deferred to #21

Per Issue #20's original scope, this build is read-only. No Preview,
Download, Remove, or Add Attachment control is wired here — those
depend on endpoints (`GET .../attachments/:attachmentId`,
`GET .../download`, `DELETE .../attachmentId`) that don't exist yet and
belong to Issue #21. Removed attachments already display correctly if
any exist (filename, size, upload date, removal date/reason), since the
representation always carries those fields — there's just no control to
create one yet from this screen.

`client/tests/lab-02/TicketDetail.test.tsx` covers UI-26, UI-27, UI-31
only. UI-28/29/30/32 need #21's endpoints and are noted at the top of
the file as deferred there.

## One thing worth a close look

A malformed `:id` (non-numeric) returns 404, not 400 — `api-spec.md` §6
defines only 200/403/404/500 for this endpoint, no 400 case, so a bad
id format is treated the same as "not found" rather than invented as a
new response shape.

## Verified locally

- `npx tsc --noEmit` — clean
- `npm run build` — succeeds
- Server tests: `ticket-detail.api.test.ts`, API-33–37 plus an extra
  empty-attachments case — pass
- Client tests: `TicketDetail.test.tsx` (UI-26, UI-27, UI-31) — pass,
  fetch mocked
- No `.js` files emitted under `client/src` or `client/tests`
