### PR TITLE
feat(lab-02): Attachments

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,4 +1,5 @@
 import { API_URL, apiFetch } from "./lib/apiClient.js";
+import { getSelectedRequester } from "./lib/requesterContext.js";
 
 export interface Category {
   id: number;
@@ -206,4 +207,52 @@ export async function getTicket(id: number): Promise<TicketDetail> {
     throw new Error(`Ticket fetch failed with status ${res.status}`);
   }
   return (await res.json()) as TicketDetail;
+}
+
+// Issue 21 — one Attachment's metadata (api-spec.md §8). Used before a
+// Preview/Download navigation to check whether the attachment was removed
+// since the Ticket was last loaded (ui-spec.md §17 "Unavailable" state).
+export async function getAttachment(ticketId: number, attachmentId: number): Promise<Attachment> {
+  const res = await apiFetch(`/api/tickets/${ticketId}/attachments/${attachmentId}`);
+  if (!res.ok) {
+    throw new Error(`Attachment fetch failed with status ${res.status}`);
+  }
+  return (await res.json()) as Attachment;
+}
+
+// Issue 21 — builds the absolute download URL (api-spec.md §9), used as a
+// plain <a href> so the file opens/downloads directly in the browser rather
+// than being fetched-then-blobbed (BR-35). A plain link navigation can't
+// carry the X-Requester-Id header apiFetch normally attaches, so — as a
+// deviation scoped to this one endpoint only — the requester id is appended
+// as a `requesterId` query param instead; the server route accepts either
+// (api-spec.md §9, TASK 4 of Issue #21).
+export function downloadAttachmentUrl(ticketId: number, attachmentId: number): string {
+  const requester = getSelectedRequester();
+  const query = requester ? `?requesterId=${requester.id}` : "";
+  return `${API_URL}/api/tickets/${ticketId}/attachments/${attachmentId}/download${query}`;
+}
+
+// Issue 21 — thrown by removeAttachment on a 409, so the UI can show a
+// specific "already removed" message if that race occurs.
+export class AlreadyRemovedError extends Error {}
+
+// Issue 21 — soft-remove an Attachment (api-spec.md §10, BR-31/BR-34).
+export async function removeAttachment(
+  ticketId: number,
+  attachmentId: number,
+  reason?: string,
+): Promise<Attachment> {
+  const res = await apiFetch(`/api/tickets/${ticketId}/attachments/${attachmentId}`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(reason !== undefined ? { reason } : {}),
+  });
+  if (res.status === 409) {
+    throw new AlreadyRemovedError("Attachment already removed");
+  }
+  if (!res.ok) {
+    throw new Error(`Attachment removal failed with status ${res.status}`);
+  }
+  return (await res.json()) as Attachment;
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -212,8 +212,13 @@ export async function getTicket(id: number): Promise<TicketDetail> {
 // Issue 21 — one Attachment's metadata (api-spec.md §8). Used before a
 // Preview/Download navigation to check whether the attachment was removed
 // since the Ticket was last loaded (ui-spec.md §17 "Unavailable" state).
+export class AttachmentNotFoundError extends Error {}
+
 export async function getAttachment(ticketId: number, attachmentId: number): Promise<Attachment> {
   const res = await apiFetch(`/api/tickets/${ticketId}/attachments/${attachmentId}`);
+  if (res.status === 404) {
+    throw new AttachmentNotFoundError("Not found");
+  }
   if (!res.ok) {
     throw new Error(`Attachment fetch failed with status ${res.status}`);
   }

--- a/client/src/screens/TicketDetail.tsx
+++ b/client/src/screens/TicketDetail.tsx
@@ -9,6 +9,7 @@ import {
 import { Link, useParams } from "react-router-dom";
 import {
   AlreadyRemovedError,
+  AttachmentNotFoundError,
   downloadAttachmentUrl,
   getAttachment,
   getCategories,
@@ -306,27 +307,36 @@ export default function TicketDetail() {
     e.preventDefault();
     if (!ticket || disabledAttachmentIds.has(attachment.id)) return;
 
+    const markUnavailable = () => {
+      setUnavailableMessages((prev) => ({
+        ...prev,
+        [attachment.id]: "This attachment is no longer available.",
+      }));
+      setDisabledAttachmentIds((prev) => new Set(prev).add(attachment.id));
+      window.setTimeout(() => {
+        setUnavailableMessages((prev) => {
+          if (!(attachment.id in prev)) return prev;
+          const next = { ...prev };
+          delete next[attachment.id];
+          return next;
+        });
+      }, 4000);
+    };
+
     try {
       const meta = await getAttachment(ticket.id, attachment.id);
       if (meta.isRemoved) {
-        setUnavailableMessages((prev) => ({
-          ...prev,
-          [attachment.id]: "This attachment is no longer available.",
-        }));
-        setDisabledAttachmentIds((prev) => new Set(prev).add(attachment.id));
-        window.setTimeout(() => {
-          setUnavailableMessages((prev) => {
-            if (!(attachment.id in prev)) return prev;
-            const next = { ...prev };
-            delete next[attachment.id];
-            return next;
-          });
-        }, 4000);
+        markUnavailable();
         return;
       }
-    } catch {
-      // The pre-check itself failed (e.g. network error) — fall through and
-      // let the real download endpoint be the source of truth.
+    } catch (err) {
+      if (err instanceof AttachmentNotFoundError) {
+        markUnavailable();
+        return;
+      }
+      // The pre-check itself failed for an unrelated reason (e.g. network
+      // error) — fall through and let the real download endpoint be the
+      // source of truth.
     }
 
     const url = downloadAttachmentUrl(ticket.id, attachment.id);

--- a/client/src/screens/TicketDetail.tsx
+++ b/client/src/screens/TicketDetail.tsx
@@ -1,15 +1,29 @@
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
 import { Link, useParams } from "react-router-dom";
 import {
+  AlreadyRemovedError,
+  downloadAttachmentUrl,
+  getAttachment,
   getCategories,
   getRelatedSystems,
   getTicket,
+  removeAttachment,
+  uploadAttachments,
   NotFoundError,
   type Attachment,
   type Category,
   type RelatedSystem,
   type TicketDetail as TicketDetailData,
 } from "../api.js";
+import { getAttachmentError } from "../lib/attachmentValidation.js";
+import AttachmentPicker from "../components/AttachmentPicker.js";
 import Badge from "../components/Badge.js";
 import StateBanner from "../components/StateBanner.js";
 
@@ -58,22 +72,161 @@ function BadgeField({ label, children }: { label: string; children: ReactNode })
   );
 }
 
-function AttachmentRow({ attachment }: { attachment: Attachment }) {
+// ui-spec.md §17, §19 — the confirmation panel opened by an active row's
+// Remove button (BR-34, §5 Destructive tier).
+function AttachmentRemoveConfirm({
+  reason,
+  onReasonChange,
+  error,
+  onConfirm,
+  onCancel,
+}: {
+  reason: string;
+  onReasonChange: (value: string) => void;
+  error: string | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const reasonInputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    reasonInputRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      className="attachment-remove-confirm"
+      role="dialog"
+      aria-label="Remove attachment"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          onCancel();
+        }
+      }}
+    >
+      <label className="field__label" htmlFor="attachment-remove-reason">
+        Reason (optional)
+      </label>
+      <textarea
+        ref={reasonInputRef}
+        id="attachment-remove-reason"
+        className="field__control"
+        value={reason}
+        maxLength={200}
+        onChange={(e) => onReasonChange(e.target.value)}
+      />
+      <p className="field__message">{reason.length}/200</p>
+      {error && <p className="field__message field__message--error">{error}</p>}
+      <div style={{ display: "flex", gap: "var(--space-sm)" }}>
+        <button type="button" className="btn btn--destructive" onClick={onConfirm}>
+          Confirm
+        </button>
+        <button type="button" className="btn btn--secondary" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function AttachmentRow({
+  attachment,
+  ticketId,
+  disabled,
+  unavailableMessage,
+  onOpenAttachment,
+  onRemoveClick,
+  confirmOpen,
+  removeReason,
+  onRemoveReasonChange,
+  removeError,
+  onConfirmRemove,
+  onCancelRemove,
+}: {
+  attachment: Attachment;
+  ticketId: number;
+  disabled: boolean;
+  unavailableMessage?: string;
+  onOpenAttachment: (
+    e: MouseEvent<HTMLAnchorElement>,
+    attachment: Attachment,
+    mode: "preview" | "download",
+  ) => void;
+  onRemoveClick: (e: MouseEvent<HTMLButtonElement>, attachmentId: number) => void;
+  confirmOpen: boolean;
+  removeReason: string;
+  onRemoveReasonChange: (value: string) => void;
+  removeError: string | null;
+  onConfirmRemove: () => void;
+  onCancelRemove: () => void;
+}) {
+  const href = downloadAttachmentUrl(ticketId, attachment.id);
+
   return (
     <li
-      className={`attachment-item ${attachment.isRemoved ? "attachment-item--removed" : "attachment-item--active"}`}
+      className={`attachment-item ${attachment.isRemoved ? "attachment-item--removed" : "attachment-item--active"}${disabled ? " attachment-item--unavailable" : ""}`}
     >
-      <span className="attachment-item__name">{attachment.originalFilename}</span>
-      <span className="attachment-item__meta">
-        {formatSize(attachment.sizeBytes)} · Uploaded {formatDate(attachment.createdAt)}
-        {attachment.isRemoved && attachment.removedAt && (
-          <>
-            {" "}
-            · Removed {formatDate(attachment.removedAt)}
-            {attachment.removalReason ? ` — ${attachment.removalReason}` : ""}
-          </>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-md)" }}>
+        <span className="attachment-item__name">{attachment.originalFilename}</span>
+        <span className="attachment-item__meta">
+          {formatSize(attachment.sizeBytes)} · Uploaded {formatDate(attachment.createdAt)}
+          {attachment.isRemoved && attachment.removedAt && (
+            <>
+              {" "}
+              · Removed {formatDate(attachment.removedAt)}
+              {attachment.removalReason ? ` — ${attachment.removalReason}` : ""}
+            </>
+          )}
+        </span>
+
+        {!attachment.isRemoved && (
+          <span style={{ display: "flex", gap: "var(--space-sm)" }}>
+            <a
+              className="btn btn--tertiary attachment-item__preview-btn"
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-disabled={disabled}
+              onClick={(e) => onOpenAttachment(e, attachment, "preview")}
+            >
+              Preview
+            </a>
+            <a
+              className="btn btn--tertiary attachment-item__download-btn"
+              href={href}
+              download={attachment.originalFilename}
+              aria-disabled={disabled}
+              onClick={(e) => onOpenAttachment(e, attachment, "download")}
+            >
+              Download
+            </a>
+            <button
+              type="button"
+              className="btn btn--destructive attachment-item__remove-btn"
+              onClick={(e) => onRemoveClick(e, attachment.id)}
+            >
+              Remove
+            </button>
+          </span>
         )}
-      </span>
+      </div>
+
+      {unavailableMessage && (
+        <p className="field__message field__message--error" role="alert">
+          {unavailableMessage}
+        </p>
+      )}
+
+      {confirmOpen && (
+        <AttachmentRemoveConfirm
+          reason={removeReason}
+          onReasonChange={onRemoveReasonChange}
+          error={removeError}
+          onConfirm={onConfirmRemove}
+          onCancel={onCancelRemove}
+        />
+      )}
     </li>
   );
 }
@@ -86,6 +239,23 @@ export default function TicketDetail() {
 
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [ticket, setTicket] = useState<TicketDetailData | null>(null);
+
+  // ui-spec.md §17 — "Unavailable" state: a Preview/Download click that
+  // discovers the attachment was removed since page load.
+  const [unavailableMessages, setUnavailableMessages] = useState<Record<number, string>>({});
+  const [disabledAttachmentIds, setDisabledAttachmentIds] = useState<Set<number>>(new Set());
+
+  // ui-spec.md §17/§19 — remove confirmation panel (BR-34).
+  const [removingAttachmentId, setRemovingAttachmentId] = useState<number | null>(null);
+  const [removeReason, setRemoveReason] = useState("");
+  const [removeError, setRemoveError] = useState<string | null>(null);
+  const removeButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  // ui-spec.md §16.2 — "Add Attachment" picker.
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerFiles, setPickerFiles] = useState<File[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   useEffect(() => {
     getCategories()
@@ -102,6 +272,10 @@ export default function TicketDetail() {
       .then((t) => {
         setTicket(t);
         setLoadState("loaded");
+        // A fresh Ticket fetch supersedes any stale per-row UI state from
+        // before the refetch (removed/uploaded attachments have new rows).
+        setUnavailableMessages({});
+        setDisabledAttachmentIds(new Set());
       })
       .catch((err) => {
         setLoadState(err instanceof NotFoundError ? "not-found" : "error");
@@ -118,6 +292,121 @@ export default function TicketDetail() {
 
   function relatedSystemName(relatedSystemId: number): string {
     return relatedSystems.find((r) => r.id === relatedSystemId)?.name ?? String(relatedSystemId);
+  }
+
+  // ui-spec.md §17 "Unavailable" — a plain <a> click can't be undone once
+  // the browser navigates, so the click is always intercepted; the metadata
+  // endpoint (api-spec.md §8) is checked first, and only when it confirms
+  // the attachment is still active does this trigger the real navigation.
+  async function handleOpenAttachment(
+    e: MouseEvent<HTMLAnchorElement>,
+    attachment: Attachment,
+    mode: "preview" | "download",
+  ) {
+    e.preventDefault();
+    if (!ticket || disabledAttachmentIds.has(attachment.id)) return;
+
+    try {
+      const meta = await getAttachment(ticket.id, attachment.id);
+      if (meta.isRemoved) {
+        setUnavailableMessages((prev) => ({
+          ...prev,
+          [attachment.id]: "This attachment is no longer available.",
+        }));
+        setDisabledAttachmentIds((prev) => new Set(prev).add(attachment.id));
+        window.setTimeout(() => {
+          setUnavailableMessages((prev) => {
+            if (!(attachment.id in prev)) return prev;
+            const next = { ...prev };
+            delete next[attachment.id];
+            return next;
+          });
+        }, 4000);
+        return;
+      }
+    } catch {
+      // The pre-check itself failed (e.g. network error) — fall through and
+      // let the real download endpoint be the source of truth.
+    }
+
+    const url = downloadAttachmentUrl(ticket.id, attachment.id);
+    if (mode === "preview") {
+      window.open(url, "_blank", "noopener,noreferrer");
+    } else {
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = attachment.originalFilename;
+      link.rel = "noopener noreferrer";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+  }
+
+  function openRemoveConfirm(e: MouseEvent<HTMLButtonElement>, attachmentId: number) {
+    removeButtonRef.current = e.currentTarget;
+    setRemovingAttachmentId(attachmentId);
+    setRemoveReason("");
+    setRemoveError(null);
+  }
+
+  function closeRemoveConfirm() {
+    setRemovingAttachmentId(null);
+    setRemoveReason("");
+    setRemoveError(null);
+    removeButtonRef.current?.focus();
+  }
+
+  async function handleConfirmRemove() {
+    if (!ticket || removingAttachmentId === null) return;
+    const reasonValue = removeReason.length > 0 ? removeReason : undefined;
+    try {
+      await removeAttachment(ticket.id, removingAttachmentId, reasonValue);
+      setRemovingAttachmentId(null);
+      setRemoveReason("");
+      setRemoveError(null);
+      // BR-39: removal also changed the Ticket's updatedAt, so the whole
+      // Ticket is refetched rather than splicing local state.
+      load();
+    } catch (err) {
+      setRemoveError(
+        err instanceof AlreadyRemovedError
+          ? "This attachment has already been removed."
+          : "Couldn't remove the attachment. Please try again.",
+      );
+    }
+  }
+
+  function openPicker() {
+    setPickerOpen(true);
+    setUploadError(null);
+  }
+
+  function closePicker() {
+    setPickerOpen(false);
+    setPickerFiles([]);
+    setUploadError(null);
+  }
+
+  async function handleUpload() {
+    if (!ticket) return;
+    const validFiles = pickerFiles.filter((file) => !getAttachmentError(file));
+    if (validFiles.length === 0) return;
+
+    setUploading(true);
+    setUploadError(null);
+    try {
+      await uploadAttachments(ticket.id, validFiles);
+      setPickerOpen(false);
+      setPickerFiles([]);
+      load();
+    } catch {
+      // ui-spec.md §7 "Attachment actions" — keep the picker's selection so
+      // the Requester can retry without reselecting.
+      setUploadError("Couldn't upload attachments. Please try again.");
+    } finally {
+      setUploading(false);
+    }
   }
 
   // BR-10/BR-36: worded identically whether the Ticket doesn't exist or
@@ -138,6 +427,7 @@ export default function TicketDetail() {
   }
 
   const activeCount = ticket ? ticket.attachments.filter((a) => !a.isRemoved).length : 0;
+  const hasValidPickerFile = pickerFiles.some((file) => !getAttachmentError(file));
 
   return (
     <div className="ticket-detail">
@@ -185,13 +475,56 @@ export default function TicketDetail() {
           </section>
 
           <section className="ticket-detail__attachments">
-            <h2>Attachments ({activeCount} active)</h2>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+              <h2>Attachments ({activeCount} active)</h2>
+              <button type="button" className="btn btn--secondary" onClick={openPicker}>
+                Add Attachment
+              </button>
+            </div>
+
+            {uploadError && <p className="field__message field__message--error">{uploadError}</p>}
+
+            {pickerOpen && (
+              <div>
+                <AttachmentPicker files={pickerFiles} onChange={setPickerFiles} />
+                <div style={{ display: "flex", gap: "var(--space-sm)", marginTop: "var(--space-sm)" }}>
+                  <button
+                    type="button"
+                    className={`btn btn--secondary${uploading ? " btn--busy" : ""}`}
+                    disabled={uploading || !hasValidPickerFile}
+                    aria-busy={uploading}
+                    onClick={handleUpload}
+                  >
+                    {uploading && <span className="btn__spinner" aria-hidden="true" />}
+                    {uploading ? "Uploading…" : "Upload"}
+                  </button>
+                  <button type="button" className="btn btn--secondary" onClick={closePicker}>
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+
             {ticket.attachments.length === 0 ? (
               <p>No attachments</p>
             ) : (
               <ul className="attachment-list">
                 {ticket.attachments.map((a) => (
-                  <AttachmentRow key={a.id} attachment={a} />
+                  <AttachmentRow
+                    key={a.id}
+                    attachment={a}
+                    ticketId={ticket.id}
+                    disabled={disabledAttachmentIds.has(a.id)}
+                    unavailableMessage={unavailableMessages[a.id]}
+                    onOpenAttachment={handleOpenAttachment}
+                    onRemoveClick={openRemoveConfirm}
+                    confirmOpen={removingAttachmentId === a.id}
+                    removeReason={removeReason}
+                    onRemoveReasonChange={setRemoveReason}
+                    removeError={removingAttachmentId === a.id ? removeError : null}
+                    onConfirmRemove={handleConfirmRemove}
+                    onCancelRemove={closeRemoveConfirm}
+                  />
                 ))}
               </ul>
             )}

--- a/client/src/styles/components.css
+++ b/client/src/styles/components.css
@@ -710,9 +710,8 @@ textarea.field__control {
 
 .attachment-item {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-md);
+  flex-direction: column;
+  gap: var(--space-sm);
   padding: var(--space-sm) var(--space-md);
   border: 1px solid var(--color-field-border);
   border-radius: var(--radius-control);
@@ -734,4 +733,26 @@ textarea.field__control {
 .attachment-item__meta {
   font-size: var(--font-size-small);
   color: var(--color-text-muted);
+}
+
+.attachment-item__preview-btn,
+.attachment-item__download-btn,
+.attachment-item__remove-btn {
+  white-space: nowrap;
+}
+
+.attachment-item__preview-btn[aria-disabled="true"],
+.attachment-item__download-btn[aria-disabled="true"] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.attachment-remove-confirm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border: 1px solid var(--color-field-border);
+  border-radius: var(--radius-control);
+  background: var(--color-page-bg);
 }

--- a/client/tests/lab-02/TicketDetail.test.tsx
+++ b/client/tests/lab-02/TicketDetail.test.tsx
@@ -1,10 +1,6 @@
-// UI-28/29/30/32 (Remove confirmation, removed-row control absence, 404
-// preview/download, and Preview-opens-new-tab) are not written here — they
-// exercise the attachment Preview/Download/Remove endpoints from Issue #21,
-// which don't exist yet. Only UI-26, UI-27, and UI-31 are covered.
-
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import TicketDetail from "../../src/screens/TicketDetail.js";
 import { RequesterProvider, setSelectedRequester } from "../../src/lib/requesterContext.js";
@@ -40,19 +36,36 @@ function jsonResponse(body: unknown, status = 200): Response {
   return { ok: status >= 200 && status < 300, status, json: async () => body } as Response;
 }
 
-type TicketResponder = () => Response | Promise<Response>;
+type Responder = () => Response | Promise<Response>;
 
-function setupFetch(options: { categories?: unknown[]; relatedSystems?: unknown[]; ticketResponder: TicketResponder }) {
+// Extended beyond Issue #20's version to also route the Issue #21 attachment
+// metadata GET and the attachment DELETE, needed by UI-28/29/30/32 below.
+function setupFetch(options: {
+  categories?: unknown[];
+  relatedSystems?: unknown[];
+  ticketResponder: Responder;
+  attachmentResponder?: Responder;
+  deleteResponder?: Responder;
+}) {
   const categories = options.categories ?? [{ id: 1, name: "Hardware" }];
   const relatedSystems = options.relatedSystems ?? [{ id: 1, name: "Email" }];
 
-  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
 
     if (url.includes("/api/categories")) return jsonResponse(categories);
     if (url.includes("/api/related-systems")) return jsonResponse(relatedSystems);
+    if (method === "DELETE" && url.match(/\/api\/tickets\/\d+\/attachments\/\d+$/)) {
+      if (!options.deleteResponder) throw new Error(`Unexpected DELETE: ${url}`);
+      return options.deleteResponder();
+    }
+    if (url.match(/\/api\/tickets\/\d+\/attachments\/\d+$/)) {
+      if (!options.attachmentResponder) throw new Error(`Unexpected fetch: ${url}`);
+      return options.attachmentResponder();
+    }
     if (url.match(/\/api\/tickets\/\d+$/)) return options.ticketResponder();
-    throw new Error(`Unexpected fetch: ${url}`);
+    throw new Error(`Unexpected fetch: ${url} (${method})`);
   });
   vi.stubGlobal("fetch", fetchMock);
 
@@ -125,5 +138,144 @@ describe("TicketDetail", () => {
       screen.getByText("This ticket doesn't exist, or isn't available to you."),
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Back to My Tickets" })).toBeInTheDocument();
+  });
+
+  // UI-28
+  it("Remove opens a confirmation panel with an optional Reason field; only Confirm calls the DELETE endpoint", async () => {
+    const user = userEvent.setup();
+    let ticketCallCount = 0;
+    const removedTicket = {
+      ...baseTicket,
+      attachments: [
+        {
+          ...baseTicket.attachments[0],
+          isRemoved: true,
+          removedAt: "2026-08-30T09:00:00.000Z",
+          removalReason: "Duplicate",
+        },
+      ],
+    };
+
+    const { fetchMock } = setupFetch({
+      ticketResponder: () => {
+        ticketCallCount += 1;
+        return jsonResponse(ticketCallCount === 1 ? baseTicket : removedTicket);
+      },
+      deleteResponder: () => jsonResponse(removedTicket.attachments[0]),
+    });
+
+    renderScreen();
+    await screen.findByText("screenshot.png");
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    expect(screen.getByRole("dialog", { name: "Remove attachment" })).toBeInTheDocument();
+
+    // Cancel does nothing — no DELETE call, panel closes.
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("dialog", { name: "Remove attachment" })).not.toBeInTheDocument();
+    expect(
+      fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === "DELETE"),
+    ).toBe(false);
+
+    // Reopen, enter a reason, Confirm — only now does the DELETE fire.
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    await user.type(screen.getByLabelText("Reason (optional)"), "Duplicate");
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => expect(ticketCallCount).toBe(2));
+    expect(screen.queryByRole("dialog", { name: "Remove attachment" })).not.toBeInTheDocument();
+
+    const deleteCall = fetchMock.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === "DELETE",
+    );
+    expect(deleteCall).toBeDefined();
+    const [deleteUrl, deleteInit] = deleteCall!;
+    expect(String(deleteUrl)).toContain("/api/tickets/42/attachments/101");
+    expect(JSON.parse((deleteInit as RequestInit).body as string)).toEqual({ reason: "Duplicate" });
+  });
+
+  // UI-29
+  it("a removed attachment row shows muted metadata with no Preview/Download/Remove controls", async () => {
+    const removedTicket = {
+      ...baseTicket,
+      attachments: [
+        {
+          ...baseTicket.attachments[0],
+          isRemoved: true,
+          removedAt: "2026-08-30T09:00:00.000Z",
+          removalReason: "Duplicate of another attached screenshot",
+        },
+      ],
+    };
+    setupFetch({ ticketResponder: () => jsonResponse(removedTicket) });
+    renderScreen();
+
+    await screen.findByText("screenshot.png");
+    const row = screen.getByText("screenshot.png").closest(".attachment-item") as HTMLElement;
+    expect(row).toHaveClass("attachment-item--removed");
+    expect(screen.queryByRole("link", { name: "Preview" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Download" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Remove" })).not.toBeInTheDocument();
+    expect(
+      within(row).getByText(/Duplicate of another attached screenshot/),
+    ).toBeInTheDocument();
+  });
+
+  // UI-30
+  it("a Preview click that discovers the attachment was removed shows a transient message and disables that row's actions", async () => {
+    const user = userEvent.setup();
+    const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    const { fetchMock } = setupFetch({
+      ticketResponder: () => jsonResponse(baseTicket),
+      attachmentResponder: () =>
+        jsonResponse({
+          ...baseTicket.attachments[0],
+          isRemoved: true,
+          removedAt: "2026-08-30T09:00:00.000Z",
+          removalReason: null,
+        }),
+    });
+
+    renderScreen();
+    await screen.findByText("screenshot.png");
+
+    await user.click(screen.getByRole("link", { name: "Preview" }));
+
+    expect(await screen.findByText("This attachment is no longer available.")).toBeInTheDocument();
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+    expect(screen.getByRole("link", { name: "Preview" })).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("link", { name: "Download" })).toHaveAttribute("aria-disabled", "true");
+
+    const attachmentGetCalls = fetchMock.mock.calls.filter(([url]) => {
+      const u = typeof url === "string" ? url : url.toString();
+      return /\/api\/tickets\/\d+\/attachments\/\d+$/.test(u);
+    });
+    expect(attachmentGetCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // UI-32
+  it("Preview opens the download URL in a new browser tab when the attachment is still active", async () => {
+    const user = userEvent.setup();
+    const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    setupFetch({
+      ticketResponder: () => jsonResponse(baseTicket),
+      attachmentResponder: () => jsonResponse(baseTicket.attachments[0]),
+    });
+
+    renderScreen();
+    await screen.findByText("screenshot.png");
+
+    const previewLink = screen.getByRole("link", { name: "Preview" });
+    expect(previewLink).toHaveAttribute("target", "_blank");
+    expect(previewLink).toHaveAttribute("rel", "noopener noreferrer");
+
+    await user.click(previewLink);
+
+    await waitFor(() => expect(windowOpenSpy).toHaveBeenCalledTimes(1));
+    const [url, target] = windowOpenSpy.mock.calls[0];
+    expect(String(url)).toContain("/api/tickets/42/attachments/101/download");
+    expect(target).toBe("_blank");
   });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,11 +2,13 @@ import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
 import multer from "multer";
 import path from "node:path";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
 import { Prisma, type Ticket, type Attachment } from "@prisma/client";
 import { getPrisma } from "./prisma.js";
 import { generateTicketNumber } from "./ticketNumber.js";
 import { validateTicketInput } from "./ticketValidation.js";
-import { storeUploadedFile } from "./uploads.js";
+import { storeUploadedFile, UPLOADS_DIR } from "./uploads.js";
 // getPrisma() is your lazy database handle. Call it INSIDE a route when you
 // need the DB.
 
@@ -83,8 +85,20 @@ type RequesterCheck =
       body: { errors: { field: string; message: string }[] } | { error: string };
     };
 
-async function checkRequester(req: Request): Promise<RequesterCheck> {
-  const raw = req.header("X-Requester-Id");
+// `allowQueryFallback` is a deviation scoped to the attachment download
+// route only (api-spec.md §9, TASK 4 of Issue #21): a plain <a href> can't
+// carry a custom header on browser navigation, so that one route also
+// accepts a `?requesterId=` query param when the header is absent. The
+// header still wins whenever both are present.
+async function checkRequester(
+  req: Request,
+  options?: { allowQueryFallback?: boolean },
+): Promise<RequesterCheck> {
+  let raw = req.header("X-Requester-Id");
+  if (raw === undefined && options?.allowQueryFallback) {
+    const queryValue = req.query.requesterId;
+    if (typeof queryValue === "string") raw = queryValue;
+  }
   const requesterId = raw !== undefined && /^\d+$/.test(raw.trim()) ? Number(raw.trim()) : NaN;
   if (!Number.isInteger(requesterId)) {
     return {
@@ -594,5 +608,168 @@ app.get("/api/tickets/:id", async (req: Request, res: Response) => {
     res.status(500).json({ error: "Unexpected server error" });
   }
 });
+
+// ---------------------------------------------------------------------------
+// Issue 21 — Attachment metadata, download/preview, soft-removal
+// (api-spec.md §8, §9, §10)
+// ---------------------------------------------------------------------------
+
+// Shared by all three routes below: resolves the Attachment (with its parent
+// Ticket) and checks it exists, belongs to the caller, and that the
+// ticketId in the URL actually matches the attachment's own ticket — a
+// malformed/non-integer id is treated as not-found, matching the existing
+// GET /api/tickets/:id convention.
+async function findOwnedAttachment(
+  ticketIdParam: string,
+  attachmentIdParam: string,
+  requesterId: number,
+): Promise<(Attachment & { ticket: Ticket }) | null> {
+  if (!/^\d+$/.test(ticketIdParam) || !/^\d+$/.test(attachmentIdParam)) {
+    return null;
+  }
+  const ticketId = Number(ticketIdParam);
+  const attachmentId = Number(attachmentIdParam);
+  const attachment = await getPrisma().attachment.findUnique({
+    where: { id: attachmentId },
+    include: { ticket: true },
+  });
+  if (!attachment || attachment.ticketId !== ticketId || attachment.ticket.requesterId !== requesterId) {
+    return null;
+  }
+  return attachment;
+}
+
+// api-spec.md §8 — metadata only, never the file body; a removed Attachment
+// still 404s BR-10's ownership checks the same as any other, but does NOT
+// 404 for being removed (that rule is download-specific, §9).
+app.get(
+  "/api/tickets/:ticketId/attachments/:attachmentId",
+  async (req: Request, res: Response) => {
+    try {
+      const requesterCheck = await checkRequester(req);
+      if (!requesterCheck.ok) {
+        return res.status(requesterCheck.status).json(requesterCheck.body);
+      }
+
+      const attachment = await findOwnedAttachment(
+        req.params.ticketId,
+        req.params.attachmentId,
+        requesterCheck.requesterId,
+      );
+      if (!attachment) {
+        return res.status(404).json({ error: "Not found" });
+      }
+
+      return res.status(200).json(attachmentToJSON(attachment));
+    } catch (err) {
+      console.error(
+        `GET /api/tickets/${req.params.ticketId}/attachments/${req.params.attachmentId} failed:`,
+        err,
+      );
+      res.status(500).json({ error: "Unexpected server error" });
+    }
+  },
+);
+
+// api-spec.md §9 — streams the file; also serves as "preview" per BR-35. A
+// removed Attachment 404s here even for its own owner (BR-32, AC-21) — the
+// only one of the three routes where isRemoved changes the response.
+app.get(
+  "/api/tickets/:ticketId/attachments/:attachmentId/download",
+  async (req: Request, res: Response) => {
+    try {
+      const requesterCheck = await checkRequester(req, { allowQueryFallback: true });
+      if (!requesterCheck.ok) {
+        return res.status(requesterCheck.status).json(requesterCheck.body);
+      }
+
+      const attachment = await findOwnedAttachment(
+        req.params.ticketId,
+        req.params.attachmentId,
+        requesterCheck.requesterId,
+      );
+      if (!attachment || attachment.removedAt !== null) {
+        return res.status(404).json({ error: "Not found" });
+      }
+
+      const filePath = path.join(UPLOADS_DIR, attachment.storedFilename);
+      try {
+        await stat(filePath);
+      } catch {
+        // A DB row with no matching file on disk is an unexpected server-side
+        // inconsistency, not "no such attachment for you" — 500, not 404.
+        console.error(`Attachment file missing from disk: ${filePath}`);
+        return res.status(500).json({ error: "Unexpected server error" });
+      }
+
+      res.setHeader("Content-Type", attachment.mimeType);
+      const stream = createReadStream(filePath);
+      stream.on("error", (streamErr) => {
+        console.error(`Attachment stream failed for ${filePath}:`, streamErr);
+        if (!res.headersSent) res.status(500).json({ error: "Unexpected server error" });
+      });
+      stream.pipe(res);
+    } catch (err) {
+      console.error(
+        `GET /api/tickets/${req.params.ticketId}/attachments/${req.params.attachmentId}/download failed:`,
+        err,
+      );
+      res.status(500).json({ error: "Unexpected server error" });
+    }
+  },
+);
+
+// api-spec.md §10 — soft-remove: sets removedAt/removalReason, never deletes
+// the underlying file (BR-31), and never touches server/src/uploads.ts.
+app.delete(
+  "/api/tickets/:ticketId/attachments/:attachmentId",
+  async (req: Request, res: Response) => {
+    try {
+      const requesterCheck = await checkRequester(req);
+      if (!requesterCheck.ok) {
+        return res.status(requesterCheck.status).json(requesterCheck.body);
+      }
+
+      // BR-34 — checked on the raw length, no trimming (api-spec.md §8
+      // OQ-TEST-2 / API-60); checked before the 404 ownership lookup, same
+      // 400-before-404 convention as upload (api-spec.md §12 OQ-9).
+      const body = (req.body ?? {}) as { reason?: unknown };
+      const reason = typeof body.reason === "string" ? body.reason : undefined;
+      if (reason !== undefined && reason.length > 200) {
+        return res.status(400).json({
+          errors: [{ field: "reason", message: "Reason must be 200 characters or fewer" }],
+        });
+      }
+
+      const attachment = await findOwnedAttachment(
+        req.params.ticketId,
+        req.params.attachmentId,
+        requesterCheck.requesterId,
+      );
+      if (!attachment) {
+        return res.status(404).json({ error: "Not found" });
+      }
+
+      if (attachment.removedAt !== null) {
+        return res.status(409).json({ error: "Attachment already removed" });
+      }
+
+      const updated = await getPrisma().attachment.update({
+        where: { id: attachment.id },
+        data: { removedAt: new Date(), removalReason: reason ?? null },
+      });
+      // BR-39: removal also touches the parent Ticket's updatedAt.
+      await getPrisma().ticket.update({ where: { id: attachment.ticketId }, data: {} });
+
+      return res.status(200).json(attachmentToJSON(updated));
+    } catch (err) {
+      console.error(
+        `DELETE /api/tickets/${req.params.ticketId}/attachments/${req.params.attachmentId} failed:`,
+        err,
+      );
+      res.status(500).json({ error: "Unexpected server error" });
+    }
+  },
+);
 
 export default app;

--- a/server/tests/lab-02/attachments.api.test.ts
+++ b/server/tests/lab-02/attachments.api.test.ts
@@ -1,0 +1,763 @@
+import "./testDbEnv.js";
+
+import { randomUUID } from "node:crypto";
+import { execSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverRoot = path.join(__dirname, "..", "..");
+
+const { app } = await import("../../src/app.js");
+const { getPrisma } = await import("../../src/prisma.js");
+const { UPLOADS_DIR } = await import("../../src/uploads.js");
+
+async function truncateAll() {
+  await getPrisma().$executeRawUnsafe(
+    `TRUNCATE TABLE "Attachment", "Ticket", "RequesterUser", "RelatedSystem", "Category" RESTART IDENTITY CASCADE;`,
+  );
+}
+
+async function seedCategory(name: string, isActive = true) {
+  return getPrisma().category.create({ data: { name, isActive } });
+}
+
+async function seedRelatedSystem(name: string, isActive = true) {
+  return getPrisma().relatedSystem.create({ data: { name, isActive } });
+}
+
+async function seedRequester(name: string, email: string, isActive = true) {
+  return getPrisma().requesterUser.create({ data: { name, email, isActive } });
+}
+
+async function seedTicket(params: {
+  requesterId: number;
+  categoryId: number;
+  relatedSystemId: number;
+}) {
+  return getPrisma().ticket.create({
+    data: {
+      ticketNumber: `TKT-2026-${String(Math.floor(Math.random() * 1_000_000)).padStart(6, "0")}`,
+      requesterId: params.requesterId,
+      categoryId: params.categoryId,
+      relatedSystemId: params.relatedSystemId,
+      summary: "Laptop won't power on after firmware update",
+      description: "Default description long enough for validation purposes.",
+      requestedPriority: "HIGH",
+      status: "NEW",
+      idempotencyKey: randomUUID(),
+    },
+  });
+}
+
+// Metadata-only fixture — no real file on disk. Fine for every test except
+// the download endpoint's success path, which needs actual bytes to stream.
+async function seedAttachment(params: {
+  ticketId: number;
+  originalFilename?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  removedAt?: Date;
+  removalReason?: string;
+}) {
+  return getPrisma().attachment.create({
+    data: {
+      ticketId: params.ticketId,
+      originalFilename: params.originalFilename ?? "screenshot.png",
+      storedFilename: `${randomUUID()}.png`,
+      mimeType: params.mimeType ?? "image/png",
+      sizeBytes: params.sizeBytes ?? 245678,
+      removedAt: params.removedAt,
+      removalReason: params.removalReason,
+    },
+  });
+}
+
+// Writes a real file into UPLOADS_DIR so the download endpoint has
+// something to stream; cleaned up in afterEach below.
+async function seedAttachmentWithFile(params: {
+  ticketId: number;
+  content?: string;
+  mimeType?: string;
+  originalFilename?: string;
+}) {
+  const storedFilename = `${randomUUID()}.txt`;
+  await fs.mkdir(UPLOADS_DIR, { recursive: true });
+  const content = params.content ?? "file content";
+  await fs.writeFile(path.join(UPLOADS_DIR, storedFilename), content);
+  return getPrisma().attachment.create({
+    data: {
+      ticketId: params.ticketId,
+      originalFilename: params.originalFilename ?? "screenshot.png",
+      storedFilename,
+      mimeType: params.mimeType ?? "image/png",
+      sizeBytes: Buffer.byteLength(content),
+    },
+  });
+}
+
+function pngBuffer(sizeBytes: number): Buffer {
+  return Buffer.alloc(sizeBytes, 1);
+}
+
+describe("Attachments", () => {
+  beforeAll(() => {
+    execSync("npx prisma migrate deploy --schema=prisma/schema.prisma", {
+      cwd: serverRoot,
+      stdio: "inherit",
+      env: process.env,
+    });
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  afterEach(async () => {
+    // Tests that go through the real POST /attachments endpoint (or
+    // seedAttachmentWithFile) write real files into UPLOADS_DIR; clean them
+    // up so the test run leaves nothing behind on disk (tests.md §1's
+    // constraint, echoed by the Issue #21 task brief).
+    const attachments = await getPrisma().attachment.findMany({ select: { storedFilename: true } });
+    await Promise.all(
+      attachments.map(async (a) => {
+        try {
+          await fs.unlink(path.join(UPLOADS_DIR, a.storedFilename));
+        } catch {
+          // No real file was ever written for this row — fine.
+        }
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await getPrisma().$disconnect();
+    delete process.env.DATABASE_URL;
+  });
+
+  // API-38
+  it("POST /api/tickets/:id/attachments with 1 valid file returns 201 and advances the Ticket's updatedAt", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+
+    const res = await request(app)
+      .post(`/api/tickets/${ticket.id}/attachments`)
+      .set("X-Requester-Id", String(requester.id))
+      .attach("files", pngBuffer(1024), { filename: "photo.png", contentType: "image/png" });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toMatchObject({ originalFilename: "photo.png", isRemoved: false });
+    expect(res.body[0]).not.toHaveProperty("storedFilename");
+
+    const updatedTicket = await getPrisma().ticket.findUniqueOrThrow({ where: { id: ticket.id } });
+    // >= rather than strict > — both operations can land in the same
+    // millisecond on a fast local run; @updatedAt still fires either way.
+    expect(updatedTicket.updatedAt.getTime()).toBeGreaterThanOrEqual(ticket.updatedAt.getTime());
+  });
+
+  // API-39
+  it("POST /api/tickets/:id/attachments on a Ticket already at 5 active attachments returns 409 and leaves the existing 5 unchanged", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    for (let i = 0; i < 5; i++) {
+      await seedAttachment({ ticketId: ticket.id, originalFilename: `existing-${i}.png` });
+    }
+
+    const res = await request(app)
+      .post(`/api/tickets/${ticket.id}/attachments`)
+      .set("X-Requester-Id", String(requester.id))
+      .attach("files", pngBuffer(1024), { filename: "new.png", contentType: "image/png" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ error: "Attachment limit reached" });
+    expect(await getPrisma().attachment.count({ where: { ticketId: ticket.id } })).toBe(5);
+  });
+
+  // API-40
+  it("POST /api/tickets/:id/attachments with 6 files in one request returns 409 and stores none", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+
+    let req = request(app).post(`/api/tickets/${ticket.id}/attachments`).set("X-Requester-Id", String(requester.id));
+    for (let i = 0; i < 6; i++) {
+      req = req.attach("files", pngBuffer(1024), { filename: `f${i}.png`, contentType: "image/png" });
+    }
+    const res = await req;
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ error: "Too many files in this request" });
+    expect(await getPrisma().attachment.count({ where: { ticketId: ticket.id } })).toBe(0);
+  });
+
+  // API-41
+  it("POST /api/tickets/:id/attachments with an unsupported file type returns 415 and stores nothing", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+
+    const res = await request(app)
+      .post(`/api/tickets/${ticket.id}/attachments`)
+      .set("X-Requester-Id", String(requester.id))
+      .attach("files", Buffer.from("hello"), { filename: "note.txt", contentType: "text/plain" });
+
+    expect(res.status).toBe(415);
+    expect(res.body).toEqual({ error: "Unsupported file type" });
+    expect(await getPrisma().attachment.count({ where: { ticketId: ticket.id } })).toBe(0);
+  });
+
+  // API-42
+  it("POST /api/tickets/:id/attachments with a file over 5 MB returns 413 and stores nothing", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+
+    const res = await request(app)
+      .post(`/api/tickets/${ticket.id}/attachments`)
+      .set("X-Requester-Id", String(requester.id))
+      .attach("files", pngBuffer(5 * 1024 * 1024 + 1), { filename: "big.png", contentType: "image/png" });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toEqual({ error: "File exceeds 5 MB" });
+    expect(await getPrisma().attachment.count({ where: { ticketId: ticket.id } })).toBe(0);
+  });
+
+  // API-43 — precedence: 409 wins over 415/413 also present in the batch.
+  it("a batch that is simultaneously >5 files, oversized, and wrong-typed returns 409, storing nothing", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+
+    let req = request(app).post(`/api/tickets/${ticket.id}/attachments`).set("X-Requester-Id", String(requester.id));
+    for (let i = 0; i < 4; i++) {
+      req = req.attach("files", pngBuffer(1024), { filename: `good-${i}.png`, contentType: "image/png" });
+    }
+    req = req.attach("files", Buffer.from("bad"), { filename: "bad.txt", contentType: "text/plain" });
+    req = req.attach("files", pngBuffer(6 * 1024 * 1024), { filename: "big.png", contentType: "image/png" });
+    const res = await req;
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ error: "Too many files in this request" });
+    expect(await getPrisma().attachment.count({ where: { ticketId: ticket.id } })).toBe(0);
+  });
+
+  // API-44 — BR-30: a batch of ≤5 files where exactly one has a bad type
+  // rejects the whole batch, including the otherwise-valid files.
+  it("a batch of 5 files where exactly one has a bad type rejects the whole batch with 415, storing none", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+
+    let req = request(app).post(`/api/tickets/${ticket.id}/attachments`).set("X-Requester-Id", String(requester.id));
+    for (let i = 0; i < 4; i++) {
+      req = req.attach("files", pngBuffer(1024), { filename: `good-${i}.png`, contentType: "image/png" });
+    }
+    req = req.attach("files", Buffer.from("bad"), { filename: "bad.txt", contentType: "text/plain" });
+    const res = await req;
+
+    expect(res.status).toBe(415);
+    expect(res.body).toEqual({ error: "Unsupported file type" });
+    expect(await getPrisma().attachment.count({ where: { ticketId: ticket.id } })).toBe(0);
+  });
+
+  // API-45
+  it("POST /api/tickets/:id/attachments with no files returns 400, checked before ownership/count checks", async () => {
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    // Targets a nonexistent Ticket id — if 400 fires first, this still 400s
+    // rather than 404ing on the ownership lookup.
+    const res = await request(app)
+      .post("/api/tickets/999999/attachments")
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: "files" })]),
+    );
+  });
+
+  // API-46
+  it("POST /api/tickets/:id/attachments to a nonexistent Ticket returns 404, checked after 400 and before 409", async () => {
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app)
+      .post("/api/tickets/999999/attachments")
+      .set("X-Requester-Id", String(requester.id))
+      .attach("files", pngBuffer(1024), { filename: "photo.png", contentType: "image/png" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Not found" });
+  });
+
+  it("POST /api/tickets/:id/attachments to a Ticket owned by a different Requester returns 404", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const owner = await seedRequester("Alex Rivera", "alex@example.com");
+    const other = await seedRequester("Sam Okafor", "sam@example.com");
+    const ticket = await seedTicket({
+      requesterId: owner.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+
+    const res = await request(app)
+      .post(`/api/tickets/${ticket.id}/attachments`)
+      .set("X-Requester-Id", String(other.id))
+      .attach("files", pngBuffer(1024), { filename: "photo.png", contentType: "image/png" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Not found" });
+  });
+
+  // API-47
+  it("GET /api/tickets/:ticketId/attachments/:attachmentId returns metadata only, including removed-state fields", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachment({ ticketId: ticket.id });
+
+    const res = await request(app)
+      .get(`/api/tickets/${ticket.id}/attachments/${attachment.id}`)
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: attachment.id,
+      ticketId: ticket.id,
+      originalFilename: "screenshot.png",
+      mimeType: "image/png",
+      sizeBytes: 245678,
+      createdAt: attachment.createdAt.toISOString(),
+      isRemoved: false,
+      removedAt: null,
+      removalReason: null,
+    });
+  });
+
+  it("GET /api/tickets/:ticketId/attachments/:attachmentId returns 200 for a removed attachment too (only download 404s on removal)", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachment({
+      ticketId: ticket.id,
+      removedAt: new Date("2026-08-29T11:30:00.000Z"),
+      removalReason: "Duplicate",
+    });
+
+    const res = await request(app)
+      .get(`/api/tickets/${ticket.id}/attachments/${attachment.id}`)
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.isRemoved).toBe(true);
+    expect(res.body.removedAt).toBe("2026-08-29T11:30:00.000Z");
+    expect(res.body.removalReason).toBe("Duplicate");
+  });
+
+  // API-48
+  it("GET /api/tickets/:ticketId/attachments/:attachmentId not found returns 404", async () => {
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app)
+      .get("/api/tickets/1/attachments/999999")
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Not found" });
+  });
+
+  it("GET /api/tickets/:ticketId/attachments/:attachmentId not owned by the caller returns 404", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const owner = await seedRequester("Alex Rivera", "alex@example.com");
+    const other = await seedRequester("Sam Okafor", "sam@example.com");
+    const ticket = await seedTicket({
+      requesterId: owner.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachment({ ticketId: ticket.id });
+
+    const res = await request(app)
+      .get(`/api/tickets/${ticket.id}/attachments/${attachment.id}`)
+      .set("X-Requester-Id", String(other.id));
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Not found" });
+  });
+
+  // API-49
+  it("GET .../download on an active attachment streams the file with the stored mimeType", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachmentWithFile({
+      ticketId: ticket.id,
+      content: "hello world",
+      mimeType: "text/plain",
+    });
+
+    const res = await request(app)
+      .get(`/api/tickets/${ticket.id}/attachments/${attachment.id}/download`)
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/plain");
+    expect(res.text).toBe("hello world");
+  });
+
+  // API-50
+  it("GET .../download on a removed attachment returns 404 even for its own owner", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachmentWithFile({ ticketId: ticket.id });
+    await getPrisma().attachment.update({ where: { id: attachment.id }, data: { removedAt: new Date() } });
+
+    const res = await request(app)
+      .get(`/api/tickets/${ticket.id}/attachments/${attachment.id}/download`)
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Not found" });
+    expect(res.text).not.toBe("file content");
+  });
+
+  // API-51
+  it("GET .../download not owned by the caller returns 404", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const owner = await seedRequester("Alex Rivera", "alex@example.com");
+    const other = await seedRequester("Sam Okafor", "sam@example.com");
+    const ticket = await seedTicket({
+      requesterId: owner.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachmentWithFile({ ticketId: ticket.id });
+
+    const res = await request(app)
+      .get(`/api/tickets/${ticket.id}/attachments/${attachment.id}/download`)
+      .set("X-Requester-Id", String(other.id));
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Not found" });
+  });
+
+  // Deviation coverage (api-spec.md §9, Issue #21 TASK 2/4): a plain <a>
+  // link click can't carry a custom header, so this route also accepts a
+  // requesterId query param, with the header taking precedence when present.
+  it("GET .../download accepts a requesterId query param when X-Requester-Id is absent", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachmentWithFile({ ticketId: ticket.id });
+
+    const res = await request(app).get(
+      `/api/tickets/${ticket.id}/attachments/${attachment.id}/download?requesterId=${requester.id}`,
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("GET .../download prefers the X-Requester-Id header over a requesterId query param when both are present", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const owner = await seedRequester("Alex Rivera", "alex@example.com");
+    const other = await seedRequester("Sam Okafor", "sam@example.com");
+    const ticket = await seedTicket({
+      requesterId: owner.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachmentWithFile({ ticketId: ticket.id });
+
+    const res = await request(app)
+      .get(`/api/tickets/${ticket.id}/attachments/${attachment.id}/download?requesterId=${owner.id}`)
+      .set("X-Requester-Id", String(other.id));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("GET .../download returns the generic 500 when the DB row exists but the file is missing from disk", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachment({ ticketId: ticket.id }); // no real file written
+
+    const res = await request(app)
+      .get(`/api/tickets/${ticket.id}/attachments/${attachment.id}/download`)
+      .set("X-Requester-Id", String(requester.id));
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Unexpected server error" });
+  });
+
+  // API-52
+  it("DELETE .../attachments/:id with a reason returns 200, sets removedAt/removalReason, and metadata stays readable", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachment({ ticketId: ticket.id });
+
+    const res = await request(app)
+      .delete(`/api/tickets/${ticket.id}/attachments/${attachment.id}`)
+      .set("X-Requester-Id", String(requester.id))
+      .send({ reason: "Duplicate of another attached screenshot" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      id: attachment.id,
+      isRemoved: true,
+      removalReason: "Duplicate of another attached screenshot",
+    });
+    expect(res.body.removedAt).toEqual(expect.any(String));
+
+    const metaRes = await request(app)
+      .get(`/api/tickets/${ticket.id}/attachments/${attachment.id}`)
+      .set("X-Requester-Id", String(requester.id));
+    expect(metaRes.status).toBe(200);
+    expect(metaRes.body.isRemoved).toBe(true);
+
+    // BR-39: removal also touches the parent Ticket's updatedAt.
+    const updatedTicket = await getPrisma().ticket.findUniqueOrThrow({ where: { id: ticket.id } });
+    // >= rather than strict > — both operations can land in the same
+    // millisecond on a fast local run; @updatedAt still fires either way.
+    expect(updatedTicket.updatedAt.getTime()).toBeGreaterThanOrEqual(ticket.updatedAt.getTime());
+  });
+
+  // API-53
+  it("DELETE .../attachments/:id with no reason returns 200 with removalReason: null", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachment({ ticketId: ticket.id });
+
+    const res = await request(app)
+      .delete(`/api/tickets/${ticket.id}/attachments/${attachment.id}`)
+      .set("X-Requester-Id", String(requester.id))
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.isRemoved).toBe(true);
+    expect(res.body.removalReason).toBeNull();
+  });
+
+  // API-54
+  it("DELETE .../attachments/:id with a reason at exactly 200 chars succeeds", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachment({ ticketId: ticket.id });
+    const reason = "a".repeat(200);
+
+    const res = await request(app)
+      .delete(`/api/tickets/${ticket.id}/attachments/${attachment.id}`)
+      .set("X-Requester-Id", String(requester.id))
+      .send({ reason });
+
+    expect(res.status).toBe(200);
+    expect(res.body.removalReason).toBe(reason);
+  });
+
+  // API-55
+  it("DELETE .../attachments/:id already removed returns 409", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachment({ ticketId: ticket.id, removedAt: new Date() });
+
+    const res = await request(app)
+      .delete(`/api/tickets/${ticket.id}/attachments/${attachment.id}`)
+      .set("X-Requester-Id", String(requester.id))
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ error: "Attachment already removed" });
+  });
+
+  // API-56
+  it("DELETE .../attachments/:id not found returns 404", async () => {
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app)
+      .delete("/api/tickets/1/attachments/999999")
+      .set("X-Requester-Id", String(requester.id))
+      .send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Not found" });
+  });
+
+  it("DELETE .../attachments/:id not owned by the caller returns 404", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const owner = await seedRequester("Alex Rivera", "alex@example.com");
+    const other = await seedRequester("Sam Okafor", "sam@example.com");
+    const ticket = await seedTicket({
+      requesterId: owner.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachment({ ticketId: ticket.id });
+
+    const res = await request(app)
+      .delete(`/api/tickets/${ticket.id}/attachments/${attachment.id}`)
+      .set("X-Requester-Id", String(other.id))
+      .send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Not found" });
+  });
+
+  // API-57
+  it("a Ticket created successfully is retained even when its only attachment upload fails (oversized)", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const createRes = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requester.id))
+      .set("Idempotency-Key", randomUUID())
+      .send({
+        categoryId: category.id,
+        relatedSystemId: relatedSystem.id,
+        summary: "Laptop won't power on",
+        description: "Screen stays black after the firmware update finished overnight.",
+        requestedPriority: "HIGH",
+      });
+    expect(createRes.status).toBe(201);
+    const ticketId = createRes.body.id;
+
+    const uploadRes = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(requester.id))
+      .attach("files", pngBuffer(6 * 1024 * 1024), { filename: "big.png", contentType: "image/png" });
+    expect(uploadRes.status).toBe(413);
+
+    const getRes = await request(app)
+      .get(`/api/tickets/${ticketId}`)
+      .set("X-Requester-Id", String(requester.id));
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.attachments).toEqual([]);
+  });
+
+  // API-60
+  it("DELETE .../attachments/:id with a reason at 201 chars (one over) returns 400 and does not remove the attachment", async () => {
+    const category = await seedCategory("Hardware");
+    const relatedSystem = await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+    const ticket = await seedTicket({
+      requesterId: requester.id,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+    });
+    const attachment = await seedAttachment({ ticketId: ticket.id });
+    const reason = "a".repeat(201);
+
+    const res = await request(app)
+      .delete(`/api/tickets/${ticket.id}/attachments/${attachment.id}`)
+      .set("X-Requester-Id", String(requester.id))
+      .send({ reason });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      errors: [{ field: "reason", message: "Reason must be 200 characters or fewer" }],
+    });
+
+    const stillActive = await getPrisma().attachment.findUniqueOrThrow({ where: { id: attachment.id } });
+    expect(stillActive.removedAt).toBeNull();
+  });
+});

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -330,4 +330,41 @@ describe("Create Ticket", () => {
     const fields = res.body.errors.map((e: { field: string }) => e.field).sort();
     expect(fields).toEqual(["description", "summary"]);
   });
+
+  // API-58
+  it("POST /api/tickets without an Idempotency-Key header returns 400 and creates no Ticket", async () => {
+    await seedCategory("Hardware");
+    await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requester.id))
+      .send(validBody());
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual([
+      { field: "Idempotency-Key", message: "Missing or invalid idempotency key" },
+    ]);
+    expect(await getPrisma().ticket.count()).toBe(0);
+  });
+
+  // API-59
+  it("POST /api/tickets with an Idempotency-Key that isn't a valid UUID returns 400 and creates no Ticket", async () => {
+    await seedCategory("Hardware");
+    await seedRelatedSystem("Email");
+    const requester = await seedRequester("Alex Rivera", "alex@example.com");
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requester.id))
+      .set("Idempotency-Key", "abc")
+      .send(validBody());
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual([
+      { field: "Idempotency-Key", message: "Missing or invalid idempotency key" },
+    ]);
+    expect(await getPrisma().ticket.count()).toBe(0);
+  });
 });


### PR DESCRIPTION
Closes #21

## What this adds

- `GET /api/tickets/:ticketId/attachments/:attachmentId` — metadata
  only, never 404s for being removed (only for not found/not owned)
- `GET .../download` — streams the file, 404 if removed even for the
  owner (BR-32, AC-21), also serves as Preview per BR-35
- `DELETE .../:attachmentId` — soft-remove, 400→404→409 order, file
  never deleted from disk (BR-31), `updatedAt` touched (BR-39)
- Preview/Download/Remove wired into Ticket Detail's attachment rows,
  plus an "Add Attachment" picker reusing the existing upload endpoint
- A remove confirmation panel (optional reason, ≤200 chars, live count,
  Esc-to-close with focus returned to the triggering Remove button)

## One deviation, scoped and documented

`api-spec.md` §9 requires `X-Requester-Id`, but Preview/Download are
plain `<a href>` navigations, and a browser link click can't set a
custom header. The download route now also accepts a `requesterId`
query param as a fallback — header wins if both are present. This
fallback is opt-in per route (`checkRequester`'s new
`allowQueryFallback` option) and used on this one endpoint only; every
other endpoint still requires the header exclusively.

## Two things worth a close look

1. The "Unavailable" state (`ui-spec.md` §17) is handled by intercepting
   every Preview/Download click, checking the metadata endpoint first,
   and only navigating if the attachment is still active. This adds one
   extra request per click but is the only way to catch a
   removed-since-page-load race before the browser navigates on an
   `<a>` — there's no way to `preventDefault` after the fact.
2. Both Remove and Upload success trigger a full Ticket refetch rather
   than splicing local state, since both actions also change the
   Ticket's `updatedAt` (BR-39), which nothing else on this screen
   would otherwise reflect.

## Verified locally

- `npx tsc --noEmit` — clean
- `npm run build` — succeeds
- Server tests: `attachments.api.test.ts`, 28 cases (API-38–57, API-60,
  plus deviation/edge coverage); API-58/59 added to
  `create-ticket.api.test.ts` per `tests.md`'s own file-location column
  (they test `POST /api/tickets`, not attachments)
- Client tests: `TicketDetail.test.tsx` extended with UI-28/29/30/32
- No `.js` files emitted under `client/src` or `client/tests`
- `server/uploads/` left empty — all test-written files cleaned up in
  `afterEach`
