### PR TITLE
docs(lab-02): justify e2e/lab-02/screenshots path

### DIFF
--- a/docs/lab-02/specification.md
+++ b/docs/lab-02/specification.md
@@ -524,3 +524,12 @@ Meaningful choices not already fixed by the labsheet, each with its reason:
     (`/tickets/:id`) are what a router is for; hand-rolling this via component
     state (as Lab 1's placeholder `App.tsx` does) would only reproduce a router
     poorly.
+13. Committed E2E/visual screenshots and the E2E spec files live under
+    `e2e/lab-02/screenshots/` and `e2e/lab-02/`, not the labsheet §12
+    illustration's `artifacts/lab-02/screenshots/` and `e2e/lab-02/`. `e2e/`
+    already exists as its own sibling workspace (its own `package.json` and
+    `playwright.config.ts`, separate from `client/`/`server/`), and keeping
+    the screenshots as a subdirectory of the suite that produces them avoids
+    a second top-level directory whose only contents are output from the
+    first. `tests.md` §1 and §4 document this path and use it consistently
+    throughout; nothing reads or writes `artifacts/`.


### PR DESCRIPTION
No linked Issue — a small, standalone doc correction discovered during a
final labsheet cross-check ahead of the Lab 2 release PR.

## What this fixes

Adds Assumption 13 to `specification.md` §11, justifying that
`e2e/lab-02/screenshots/` and `e2e/lab-02/` are used instead of the
labsheet §12 illustration's `artifacts/lab-02/screenshots/` path.

## Why

`e2e/` is already its own sibling workspace to `client/`/`server/`, with
its own `package.json` and `playwright.config.ts`. Keeping the committed
screenshots as a subdirectory of the suite that produces them avoids a
second top-level directory whose only contents are that suite's output.
`tests.md` §1 and §4 already document and use this path consistently —
nothing in the repo reads or writes `artifacts/`.

The labsheet's §12 structure is framed as a "Minimum Lab 2 structure"
illustration, not a literal path contract (its own example client test
filenames don't match what was actually built either, for the same
reason: illustrative, not mandatory). This is a deliberate, documented
deviation rather than a missed requirement.

## Verified locally

No code changed — doc-only. Confirmed no file in the repo references
`artifacts/lab-02/` anywhere (`tests.md`, the Playwright specs, and
`README.md` all consistently point at `e2e/lab-02/screenshots/`).
